### PR TITLE
Modified script to avoid use of OboModel::OboPrint.  

### DIFF
--- a/external_tools/release_and_checking_scripts/releases/auto_def_sub.pl
+++ b/external_tools/release_and_checking_scripts/releases/auto_def_sub.pl
@@ -6,19 +6,49 @@ use strict;
 
 my ($obo_stag, $obo_mtag, $obo_stanza, $relations, $obo_header) = OboModel::obo_parse($ARGV[0]);
 
-while (my ($id, $tag) = each %$obo_stag) {
-  if ($tag->{def} =~ m/\$sub_(\w+\:\d+)/) {
+# New dumb version imports def but not references from GO, but avoids OboModel::obo_print.
+# Since perl 5.18, this sub causes errors for stanzas with consider in => random truncation of output (!)
+
+print $$obo_header."\n";
+
+while (my ($id, $stanza) = each %$obo_stanza) {
+  if ($stanza =~ m/def: \".+\$sub_(\w+\:\d+)/) {
     my $sub_term_id = $1;
     if (exists $obo_stag->{$sub_term_id}->{def}) {
-      $tag->{def} =~ s/\$sub_(\w+\:\d+)/$obo_stag->{$sub_term_id}->{def}/;
-      $tag->{def_dbxref} = "$tag->{def_dbxref}, $obo_stag->{$sub_term_id}->{def_dbxref}"
+      $stanza =~ s/\$sub_(\w+\:\d+)/$obo_stag->{$sub_term_id}->{def}/;
+      print "\n[Term]\n$stanza\n";
     } else {
       warn "No def for $sub_term_id in source file"
     }
+  } else {
+    print "\n[Term]\n$stanza\n";  
   }
 }
 
-OboModel::obo_print($obo_stag, $obo_mtag, $obo_stanza, $relations, $obo_header);
+for (@{$relations}) {
+  print '
 
+[Typedef]
+'.$_
+    }
+print "\n";
+
+# Should probably write a simple stanza printer for OboModel.pm
+ 
+
+##  Old version: 
+
+# while (my ($id, $tag) = each %$obo_stag) {
+#   if ($tag->{def} =~ m/\$sub_(\w+\:\d+)/) {
+#     my $sub_term_id = $1;
+#     if (exists $obo_stag->{$sub_term_id}->{def}) {
+#       $tag->{def} =~ s/\$sub_(\w+\:\d+)/$obo_stag->{$sub_term_id}->{def}/;
+#       $tag->{def_dbxref} = "$tag->{def_dbxref}, $obo_stag->{$sub_term_id}->{def_dbxref}"
+#     } else {
+#       warn "No def for $sub_term_id in source file"
+#     }
+#   }
+# }
+# OboModel::obo_print($obo_stag, $obo_mtag, $obo_stanza, $relations, $obo_header);
 
 


### PR DESCRIPTION
This sub not work with perl 5.18 or later.  New version of script works on whole stanzas.  It fails to import references from GO, as the old version did.