### PR TITLE
Replace oboInOwl: annotations by dcterms: annotations.

### DIFF
--- a/src/ontology/components/dpo-simple.owl
+++ b/src/ontology/components/dpo-simple.owl
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://purl.obolibrary.org/obo/fbcv/components/dpo-simple.owl#"
      xml:base="http://purl.obolibrary.org/obo/fbcv/components/dpo-simple.owl"
+     xmlns:dcterms="http://purl.org/dc/terms/"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:ns="http://creativecommons.org/ns#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
@@ -531,19 +532,15 @@ We also have the outstanding issue of how to aim different definitions to differ
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
+    <!-- http://purl.org/dc/terms/contributor -->
 
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by">
-        <rdfs:isDefinedBy rdf:resource="http://www.geneontology.org/formats/oboinowl.owl"/>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#creation_date -->
+    <!-- http://purl.org/dc/terms/date -->
 
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date">
-        <rdfs:isDefinedBy rdf:resource="http://www.geneontology.org/formats/oboinowl.owl"/>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/date"/>
     
 
 
@@ -1096,8 +1093,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000325">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>A phenotype that is an expansion of the developing embryonic nervous system at the expense of developing ventral epidermis.</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2011-09-13T02:42:10Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-09-13T02:42:10Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000325</oboInOwl:id>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/fbcv#fbcvsubset_mgiribbons"/>
@@ -3398,8 +3395,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000387"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000394"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in circadian behavior (GO:0048512). &apos;circadian behavior&apos; is defined as: &apos;The specific behavior of an organism that recurs with a regularity of approximately 24 hours.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2009-11-30T11:06:35Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-11-30T11:06:35Z</dcterms:date>
         <oboInOwl:hasExactSynonym>circadian behavior defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000679</oboInOwl:id>
@@ -3443,8 +3440,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000681">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in sensory perception (GO:0007600). &apos;sensory perception&apos; is defined as: &apos;The series of events required for an organism to receive a sensory stimulus, convert it to a molecular signal, and recognize and characterize the signal. This is a neurological process.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-02-23T12:28:26Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-23T12:28:26Z</dcterms:date>
         <oboInOwl:hasExactSynonym>sensory perception defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000681</oboInOwl:id>
@@ -3487,8 +3484,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000683">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in response to temperature stimulus (GO:0009266). &apos;response to temperature stimulus&apos; is defined as: &apos;Any process that results in a change in state or activity of a cell or an organism (in terms of movement, secretion, enzyme production, gene expression, etc.) as a result of a temperature stimulus.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-02-23T12:51:02Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-23T12:51:02Z</dcterms:date>
         <oboInOwl:hasExactSynonym>temperature response defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000683</oboInOwl:id>
@@ -3511,8 +3508,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000408"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000683"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in response to cold (GO:0009409). &apos;response to cold&apos; is defined as: &apos;Any process that results in a change in state or activity of a cell or an organism (in terms of movement, secretion, enzyme production, gene expression, etc.) as a result of a cold stimulus, a temperature stimulus below the optimal temperature for that organism.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-02-23T02:11:27Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-02-23T02:11:27Z</dcterms:date>
         <oboInOwl:hasExactSynonym>cold stress response defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000684</oboInOwl:id>
@@ -3672,8 +3669,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000705">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in sleep (GO:0030431). &apos;sleep&apos; is defined as: &apos;Any process in which an organism enters and maintains a periodic, readily reversible state of reduced awareness and metabolic activity. Usually accompanied by physical relaxation, the onset of sleep in humans and other mammals is marked by a change in the electrical activity of the brain.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-09-20T12:06:13Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-09-20T12:06:13Z</dcterms:date>
         <oboInOwl:hasExactSynonym>sleep defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000705</oboInOwl:id>
@@ -3695,8 +3692,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000706">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in entry into diapause (GO:0055115). &apos;entry into diapause&apos; is defined as: &apos;The dormancy process that results in entry into diapause. Diapause is a neurohormonally mediated, dynamic state of low metabolic activity. Associated characteristics of this form of dormancy include reduced morphogenesis, increased resistance to environmental extremes, and altered or reduced behavioral activity. Full expression develops in a species-specific manner, usually in response to a number of environmental stimuli that precede unfavorable conditions. Once diapause has begun, metabolic activity is suppressed even if conditions favorable for development prevail. Once initiated, only certain stimuli are capable of releasing the organism from this state, and this characteristic is essential in distinguishing diapause from hibernation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-09-20T12:06:28Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-09-20T12:06:28Z</dcterms:date>
         <oboInOwl:hasExactSynonym>diapause defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000706</oboInOwl:id>
@@ -3719,8 +3716,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000707">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000706"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in entry into reproductive diapause (GO:0055116). &apos;entry into reproductive diapause&apos; is defined as: &apos;The dormancy process that results in entry into reproductive diapause. Reproductive diapause is a form of diapause where the organism itself will remain fully active, including feeding and other routine activities, but the reproductive organs experience a tissue-specific reduction in metabolism, with characteristic triggering and releasing stimuli.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2010-09-20T12:21:29Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2010-09-20T12:21:29Z</dcterms:date>
         <oboInOwl:hasExactSynonym>reproductive diapause defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000707</oboInOwl:id>
@@ -3783,8 +3780,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000713">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000415"/>
         <obo:IAO_0000115>Phenotype that is a inability to jump. This may be due to neurological or muscular defects.</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2011-03-10T04:57:06Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-03-10T04:57:06Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000713</oboInOwl:id>
         <rdfs:label>jumpless</rdfs:label>
@@ -3864,8 +3861,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000719">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007508"/>
         <obo:IAO_0000115>Phenotype that is a decrease in size of an initially normally sized organ or tissue due to wasting away of cells.</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2011-03-10T05:59:04Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-03-10T05:59:04Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000719</oboInOwl:id>
         <rdfs:label>atrophy</rdfs:label>
@@ -3885,8 +3882,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000414"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000415"/>
         <obo:IAO_0000115>Phenotype that is any abnormality or in or absence of a jump response (GO:0007630). The jump response in Drosophila is a reflex escape response that can be triggered by a number of signals including odor and light. Standard assays are commonly used to test odor and light induced jump response.</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2011-03-11T08:03:28Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-03-11T08:03:28Z</dcterms:date>
         <oboInOwl:hasExactSynonym>jump response defective</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000720</oboInOwl:id>
@@ -3993,8 +3990,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0000734">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000698"/>
         <obo:IAO_0000115>Embryonic/larval segmentation phenotype that is the complete or partial loss of terminal regions of the embryo/larva: the acron, telson and immediately adjacent segments.</obo:IAO_0000115>
-        <oboInOwl:created_by>djs93</oboInOwl:created_by>
-        <oboInOwl:creation_date>2011-09-13T02:31:53Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-7073-9172"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-09-13T02:31:53Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0000734</oboInOwl:id>
         <rdfs:label>terminal phenotype</rdfs:label>
@@ -5016,8 +5013,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in anesthesia-resistant memory (GO:0007615). &apos;anesthesia-resistant memory&apos; is defined as: &apos;The memory process that results in the formation of consolidated memory resistant to disruption of the patterned activity of the brain, without requiring protein synthesis.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:46:41Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:46:41Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007500</oboInOwl:id>
         <rdfs:label xml:lang="en">abnormal anesthesia-resistant memory</rdfs:label>
@@ -5037,8 +5034,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in short-term memory (GO:0007614). &apos;short-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received a short time (up to about 30 minutes) ago. This type of memory is typically dependent on direct, transient effects of second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:50:19Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:50:19Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007501</oboInOwl:id>
         <rdfs:label xml:lang="en">abnormal short-term memory</rdfs:label>
@@ -5058,8 +5055,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in medium-term memory (GO:0072375). &apos;medium-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received at a time ago that is intermediate between that of short and long term memory (30min - 7hrs in Drosophila melanogaster).&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:51:08Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:51:08Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007502</oboInOwl:id>
         <rdfs:label xml:lang="en">abnormal medium-term memory</rdfs:label>
@@ -5080,8 +5077,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in long-term memory (GO:0007616). &apos;long-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information a long time (typically weeks, months or years) after receiving that information. This type of memory is typically dependent on gene transcription regulated by second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:51:45Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T14:51:45Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007503</oboInOwl:id>
         <rdfs:label xml:lang="en">abnormal long-term memory</rdfs:label>
@@ -5101,8 +5098,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0001347"/>
         <obo:IAO_0000115>Phenotype that is any abnormality in body weight compared to identically raised wild-type controls.</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:47:07Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:47:07Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007504</oboInOwl:id>
         <rdfs:label xml:lang="en">abnormal body weight</rdfs:label>
@@ -5121,8 +5118,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007505">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007504"/>
         <obo:IAO_0000115>Phenotype that is an increase in body weight compared to identically raised wild-type controls.</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:50:18Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:50:18Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007505</oboInOwl:id>
         <rdfs:label xml:lang="en">increased body weight</rdfs:label>
@@ -5141,8 +5138,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007506">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007504"/>
         <obo:IAO_0000115>Phenotype that is a decrease in body weight compared to identically raised wild-type controls.</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:50:44Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:50:44Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007506</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased body weight</rdfs:label>
@@ -5161,8 +5158,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000357"/>
         <obo:IAO_0000115>A phenotype that is an increase in the size of the whole body or some body part compared to wild-type.</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:52:00Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:52:00Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007507</oboInOwl:id>
         <rdfs:label xml:lang="en">increased size</rdfs:label>
@@ -5181,8 +5178,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000357"/>
         <obo:IAO_0000115>A phenotype that is a decrease in the size of the whole body or some body part compared to wild-type.</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:52:59Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-15T15:52:59Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007508</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased size</rdfs:label>
@@ -5201,8 +5198,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007509">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000413"/>
         <obo:IAO_0000115>Phenotype that is an increase in the rate of phototaxis (GO:0042331). &apos;phototaxis&apos; is defined as: &apos;The directed movement of a motile cell or organism in response to light.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:10:39Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:10:39Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007509</oboInOwl:id>
         <rdfs:label xml:lang="en">increased rate of phototaxis</rdfs:label>
@@ -5223,8 +5220,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007510">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000413"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the rate of phototaxis (GO:0042331). &apos;phototaxis&apos; is defined as: &apos;The directed movement of a motile cell or organism in response to light.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:20:20Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:20:20Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007510</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased rate of phototaxis</rdfs:label>
@@ -5245,8 +5242,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007511">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000668"/>
         <obo:IAO_0000115>Phenotype that is an increase in the rate of cell adhesion (GO:0007155). &apos;cell adhesion&apos; is defined as: &apos;The attachment of a cell, either to another cell or to an underlying substrate such as the extracellular matrix, via cell adhesion molecules.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:21:22Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:21:22Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007511</oboInOwl:id>
         <rdfs:label xml:lang="en">increased rate of cell adhesion</rdfs:label>
@@ -5267,8 +5264,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007512">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000668"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the rate of cell adhesion (GO:0007155). &apos;cell adhesion&apos; is defined as: &apos;The attachment of a cell, either to another cell or to an underlying substrate such as the extracellular matrix, via cell adhesion molecules.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:22:22Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T09:22:22Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007512</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased rate of cell adhesion</rdfs:label>
@@ -5289,8 +5286,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007513">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000705"/>
         <obo:IAO_0000115>Phenotype that is an increase in the total amount or frequency of sleep (GO:0030431) over a given time interval, compared to wild-type. &apos;sleep&apos; is defined as: &apos;Any process in which an organism enters and maintains a periodic, readily reversible state of reduced awareness and metabolic activity. Usually accompanied by physical relaxation, the onset of sleep in humans and other mammals is marked by a change in the electrical activity of the brain.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:02:45Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:02:45Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007513</oboInOwl:id>
         <rdfs:label xml:lang="en">increased sleep</rdfs:label>
@@ -5310,8 +5307,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000705"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the total amount or frequency of sleep (GO:0030431) over a given time interval, compared to wild-type. &apos;sleep&apos; is defined as: &apos;Any process in which an organism enters and maintains a periodic, readily reversible state of reduced awareness and metabolic activity. Usually accompanied by physical relaxation, the onset of sleep in humans and other mammals is marked by a change in the electrical activity of the brain.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:12:40Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:12:40Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007514</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased sleep</rdfs:label>
@@ -5331,8 +5328,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007515">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000419"/>
         <obo:IAO_0000115>Phenotype that is an increase in the total amount or frequency of feeding behavior (GO:0007631) over a given time interval, compared to wild-type. &apos;feeding behavior&apos; is defined as: &apos;Behavior associated with the intake of food.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:14:26Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:14:26Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007515</oboInOwl:id>
         <rdfs:label xml:lang="en">increased feeding behavior</rdfs:label>
@@ -5352,8 +5349,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007516">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000419"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the total amount or frequency of feeding behavior (GO:0007631) over a given time interval, compared to wild-type. &apos;feeding behavior&apos; is defined as: &apos;Behavior associated with the intake of food.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:16:19Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-16T12:16:19Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007516</oboInOwl:id>
         <rdfs:label xml:lang="en">decreased feeding behavior</rdfs:label>
@@ -5373,8 +5370,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is an increase in the efficacy of memory (GO:0007613) relative to controls. &apos;memory&apos; is defined as: &apos;The activities involved in the mental information processing system that receives (registers), modifies, stores, and retrieves informational stimuli. The main stages involved in the formation and retrieval of memory are encoding (processing of received information by acquisition), storage (building a permanent record of received information as a result of consolidation) and retrieval (calling back the stored information and use it in a suitable way to execute a given task).&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:45:09Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:45:09Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007517</oboInOwl:id>
         <rdfs:comment>This will usually be measured as an increased magnitude/rate of a behavioral output associated with memory formation.</rdfs:comment>
@@ -5396,8 +5393,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBcv_0007518">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0000398"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the efficacy of memory (GO:0007613) relative to controls. &apos;memory&apos; is defined as: &apos;The activities involved in the mental information processing system that receives (registers), modifies, stores, and retrieves informational stimuli. The main stages involved in the formation and retrieval of memory are encoding (processing of received information by acquisition), storage (building a permanent record of received information as a result of consolidation) and retrieval (calling back the stored information and use it in a suitable way to execute a given task).&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:55:18Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:55:18Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007518</oboInOwl:id>
         <rdfs:comment>This will usually be measured as a decreased magnitude/rate of a behavioral output associated with memory formation.</rdfs:comment>
@@ -5420,8 +5417,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007501"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007517"/>
         <obo:IAO_0000115>Phenotype that is an increase in the efficacy of short-term memory (GO:0007614) relative to controls. &apos;short-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received a short time (up to about 30 minutes) ago. This type of memory is typically dependent on direct, transient effects of second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:56:41Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:56:41Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007519</oboInOwl:id>
         <rdfs:comment>This will usually be measured as an increased magnitude/rate of a behavioral output associated with short-term memory formation.</rdfs:comment>
@@ -5444,8 +5441,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007501"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007518"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the efficacy of short-term memory (GO:0007614) relative to controls. &apos;short-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received a short time (up to about 30 minutes) ago. This type of memory is typically dependent on direct, transient effects of second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:57:17Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T11:57:17Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007520</oboInOwl:id>
         <rdfs:comment>This will usually be measured as a decreased magnitude/rate of a behavioral output associated with short-term memory formation.</rdfs:comment>
@@ -5468,8 +5465,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007503"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007517"/>
         <obo:IAO_0000115>Phenotype that is an increase in the efficacy of long-term memory (GO:0007616) relative to controls. &apos;long-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information a long time (typically weeks, months or years) after receiving that information. This type of memory is typically dependent on gene transcription regulated by second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:02:59Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:02:59Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007521</oboInOwl:id>
         <rdfs:comment>This will usually be measured as an increased magnitude/rate of a behavioral output associated with long-term memory formation.</rdfs:comment>
@@ -5492,8 +5489,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007503"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007518"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the efficacy of long-term memory (GO:0007616) relative to controls. &apos;long-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information a long time (typically weeks, months or years) after receiving that information. This type of memory is typically dependent on gene transcription regulated by second messenger activation.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:04:30Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:04:30Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007522</oboInOwl:id>
         <rdfs:comment>This will usually be measured as a decreased magnitude/rate of a behavioral output associated with long-term memory formation.</rdfs:comment>
@@ -5516,8 +5513,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007500"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007517"/>
         <obo:IAO_0000115>Phenotype that is an increase in the efficacy of anesthesia-resistant memory (GO:0007615) relative to controls. &apos;anesthesia-resistant memory&apos; is defined as: &apos;The memory process that results in the formation of consolidated memory resistant to disruption of the patterned activity of the brain, without requiring protein synthesis.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:08:22Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:08:22Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007523</oboInOwl:id>
         <rdfs:comment>This will usually be measured as an increased magnitude/rate of a behavioral output associated with anesthesia-resistant memory formation.</rdfs:comment>
@@ -5540,8 +5537,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007500"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007518"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the efficacy of anesthesia-resistant memory (GO:0007615) relative to controls. &apos;anesthesia-resistant memory&apos; is defined as: &apos;The memory process that results in the formation of consolidated memory resistant to disruption of the patterned activity of the brain, without requiring protein synthesis.&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:10:03Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:10:03Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007524</oboInOwl:id>
         <rdfs:comment>This will usually be measured as a decreased magnitude/rate of a behavioral output associated with anesthesia-resistant memory formation.</rdfs:comment>
@@ -5564,8 +5561,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007502"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007517"/>
         <obo:IAO_0000115>Phenotype that is an increase in the efficacy of medium-term memory (GO:0072375) relative to controls. &apos;medium-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received at a time ago that is intermediate between that of short and long term memory (30min - 7hrs in Drosophila melanogaster).&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:11:31Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:11:31Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007525</oboInOwl:id>
         <rdfs:comment>This will usually be measured as an increased magnitude/rate of a behavioral output associated with medium-term memory formation.</rdfs:comment>
@@ -5589,8 +5586,8 @@ A continuant cannot have an occurrent as part: use &apos;participates in&apos;. 
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007502"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FBcv_0007518"/>
         <obo:IAO_0000115>Phenotype that is a decrease in the efficacy of medium-term memory (GO:0072375) relative to controls. &apos;medium-term memory&apos; is defined as: &apos;The memory process that deals with the storage, retrieval and modification of information received at a time ago that is intermediate between that of short and long term memory (30min - 7hrs in Drosophila melanogaster).&apos;</obo:IAO_0000115>
-        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
-        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:12:48Z</oboInOwl:creation_date>
+        <dcterms:contributor rdf:resource="http://orcid.org/0000-0002-1373-1705"/>
+        <dcterms:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-08-06T12:12:48Z</dcterms:date>
         <oboInOwl:hasOBONamespace>phenotypic_class</oboInOwl:hasOBONamespace>
         <oboInOwl:id>FBcv:0007526</oboInOwl:id>
         <rdfs:comment>This will usually be measured as a decreased magnitude/rate of a behavioral output associated with medium-term memory formation.</rdfs:comment>

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -4523,8 +4523,8 @@ name: 60-70% egg length
 namespace: spatial_qualifier
 def: "60-70% of egg length from the posterior tip (0%) of the egg or pre-gastrula embryo." [FBC:DOS]
 is_a: FBcv:0000074 ! egg length
-created_by: djs93
-creation_date: 2009-05-28T03:54:39Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2009-05-28T03:54:39Z xsd:dateTime
 
 [Term]
 id: FBcv:0000678
@@ -4532,8 +4532,8 @@ name: 80-100% egg length
 namespace: spatial_qualifier
 def: "80-100% of egg length from the posterior tip (0%) of the egg or pre-gastrula embryo." [FBC:DOS]
 is_a: FBcv:0000074 ! egg length
-created_by: djs93
-creation_date: 2009-05-28T03:55:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2009-05-28T03:55:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0000685
@@ -4557,8 +4557,8 @@ def: "An allele that completely lacks function, coding either for a completely i
 synonym: "amorph" RELATED []
 synonym: "null" RELATED []
 is_a: FBcv:0000287 ! loss of function allele
-created_by: djs93
-creation_date: 2010-09-06T03:57:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T03:57:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0000689
@@ -4567,8 +4567,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to completely lack function, producing either a completely inactive gene product or none at all." [FlyBase:FBrf0049147]
 synonym: "molecular null" EXACT []
 is_a: FBcv:0000688 ! amorphic allele
-created_by: djs93
-creation_date: 2010-09-06T03:57:49Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T03:57:49Z xsd:dateTime
 
 [Term]
 id: FBcv:0000690
@@ -4577,8 +4577,8 @@ namespace: allele_class
 def: "Allele that makes a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 synonym: "hypomorph" EXACT []
 is_a: FBcv:0000287 ! loss of function allele
-created_by: djs93
-creation_date: 2010-09-06T03:58:15Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T03:58:15Z xsd:dateTime
 
 [Term]
 id: FBcv:0000691
@@ -4586,8 +4586,8 @@ name: hypomorphic allele - molecular evidence
 namespace: allele_class
 def: "An allele shown by molecular evidence to make a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FlyBase:FBrf0049147]
 is_a: FBcv:0000690 ! hypomorphic allele
-created_by: djs93
-creation_date: 2010-09-06T03:59:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T03:59:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000692
@@ -4595,8 +4595,8 @@ name: neomorphic allele - molecular evidence
 namespace: allele_class
 def: "An allele shown by molecular evidence to produce a gene product with a novel function or expression pattern compared to wild-type." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 is_a: FBcv:0000697 ! neomorphic allele
-created_by: djs93
-creation_date: 2010-09-06T04:01:04Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:01:04Z xsd:dateTime
 
 [Term]
 id: FBcv:0000693
@@ -4604,8 +4604,8 @@ name: hypermorphic allele - molecular evidence
 namespace: allele_class
 def: "Allele shown by molecular evidence to make either a functionally wild-type gene product at increased levels or a gene product with the same function as wild-type but with increased activity." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 is_a: FBcv:0000696 ! hypermorphic allele
-created_by: djs93
-creation_date: 2010-09-06T04:01:04Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:01:04Z xsd:dateTime
 
 [Term]
 id: FBcv:0000694
@@ -4614,8 +4614,8 @@ namespace: allele_class
 def: "An allele that has been shown by molecular evidence to make a gene product that is antagonistic to the function of the wild-type gene product." [FlyBase:FBrf0049147]
 synonym: "dominant negative" RELATED []
 is_a: FBcv:0000695 ! antimorphic allele
-created_by: djs93
-creation_date: 2010-09-06T04:01:04Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:01:04Z xsd:dateTime
 
 [Term]
 id: FBcv:0000695
@@ -4624,8 +4624,8 @@ namespace: allele_class
 def: "An allele that makes a gene product that is antagonistic to the function of the wild-type gene product." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 synonym: "antimorph" RELATED []
 is_a: FBcv:0000290 ! gain of function allele
-created_by: djs93
-creation_date: 2010-09-06T04:02:05Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:02:05Z xsd:dateTime
 
 [Term]
 id: FBcv:0000696
@@ -4634,8 +4634,8 @@ namespace: allele_class
 def: "An allele that makes either increased amounts of a normal gene product or a gene product with normal function but increased activity compared to wild-type." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 synonym: "hypermorph" RELATED []
 is_a: FBcv:0000290 ! gain of function allele
-created_by: djs93
-creation_date: 2010-09-06T04:02:45Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:02:45Z xsd:dateTime
 
 [Term]
 id: FBcv:0000697
@@ -4644,8 +4644,8 @@ namespace: allele_class
 def: "An allele that makes a gene product with a novel function or expression pattern compared to wild-type." [FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 synonym: "neomorph" RELATED []
 is_a: FBcv:0000290 ! gain of function allele
-created_by: djs93
-creation_date: 2010-09-06T04:03:33Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-06T04:03:33Z xsd:dateTime
 
 [Term]
 id: FBcv:0000704
@@ -4653,8 +4653,8 @@ name: chemical conditional
 namespace: environmental_qualifier
 def: "Phenotype expressed only in the presence or absence of some specific chemical whose presence or absence does not induce the same defect in wild-type animals." [FBC:DOS]
 is_a: FBcv:0000309 ! conditional
-created_by: djs93
-creation_date: 2010-09-20T11:13:19Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2010-09-20T11:13:19Z xsd:dateTime
 
 [Term]
 id: FBcv:0000710
@@ -4687,8 +4687,8 @@ name: nutrition conditional
 namespace: environmental_qualifier
 def: "Phenotype only expressed under some specific nutritional regime." [FBC:DOS]
 is_a: FBcv:0000309 ! conditional
-created_by: djs93
-creation_date: 2011-01-14T12:34:01Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-01-14T12:34:01Z xsd:dateTime
 
 [Term]
 id: FBcv:0000715
@@ -4696,8 +4696,8 @@ name: calorie restriction conditional
 namespace: environmental_qualifier
 def: "Phenotype only expressed under conditions where calorie intake is restricted." [FBC:DOS]
 is_a: FBcv:0000714 ! nutrition conditional
-created_by: djs93
-creation_date: 2011-01-14T05:12:37Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-01-14T05:12:37Z xsd:dateTime
 
 [Term]
 id: FBcv:0000722
@@ -4705,8 +4705,8 @@ name: somatic clone - Minute background
 namespace: clone_qualifier
 def: "A clone of somatic cells that share a mutant genotype that includes being Minute +/+ and that is part of and derived from an animal with a different genotype that includes being Minute +/-." [FBC:DOS]
 is_a: FBcv:0000336 ! somatic clone
-created_by: djs93
-creation_date: 2011-01-27T04:55:28Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-01-27T04:55:28Z xsd:dateTime
 
 [Term]
 id: FBcv:0000726
@@ -4715,8 +4715,8 @@ namespace: sex_qualifier
 def: "Expressed in virgin females." [FBC:DOS]
 comment: May be used as a qualifier for gene or transgene expression or phenotype. Note - its use does not imply expression (of gene or phenotype) exclusively in virgin females.
 is_a: FBcv:0000334 ! female
-created_by: djs93
-creation_date: 2011-04-21T01:10:32Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:10:32Z xsd:dateTime
 
 [Term]
 id: FBcv:0000727
@@ -4725,8 +4725,8 @@ namespace: sex_qualifier
 def: "Expressed in mated females." [FBC:DOS]
 comment: May be used as a qualifier for gene or transgene expression or phenotype. Note - its use does not imply expression (of gene or phenotype) exclusively in mated females.
 is_a: FBcv:0000334 ! female
-created_by: djs93
-creation_date: 2011-04-21T01:10:49Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:10:49Z xsd:dateTime
 
 [Term]
 id: FBcv:0000728
@@ -4735,8 +4735,8 @@ namespace: sex_qualifier
 def: "Expressed in virgin males." [FBC:DOS]
 comment: May be used as a qualifier for gene or transgene expression or phenotype. Note - its use does not imply expression (of gene or phenotype) exclusively in virgin males.
 is_a: FBcv:0000333 ! male
-created_by: djs93
-creation_date: 2011-04-21T01:11:13Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:11:13Z xsd:dateTime
 
 [Term]
 id: FBcv:0000729
@@ -4745,8 +4745,8 @@ namespace: sex_qualifier
 def: "Expressed in mated males." [FBC:DOS]
 comment: May be used as a qualifier for gene or transgene expression or phenotype. Note - its use does not imply expression (of gene or phenotype) exclusively in mated females.
 is_a: FBcv:0000333 ! male
-created_by: djs93
-creation_date: 2011-04-21T01:11:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:11:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0000730
@@ -4755,8 +4755,8 @@ namespace: sex_qualifier
 def: "Expression is limited to virgin females." [FBC:DOS]
 comment: May be used to qualify expression of phenotypes or of genes, transgenes etc.
 is_a: FBcv:0000308 ! female limited
-created_by: djs93
-creation_date: 2011-04-21T01:11:46Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:11:46Z xsd:dateTime
 
 [Term]
 id: FBcv:0000731
@@ -4765,8 +4765,8 @@ namespace: sex_qualifier
 def: "Expression is limited to mated females." [FBC:DOS]
 comment: May be used to qualify expression of phenotypes or of genes, transgenes etc.
 is_a: FBcv:0000308 ! female limited
-created_by: djs93
-creation_date: 2011-04-21T01:11:59Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:11:59Z xsd:dateTime
 
 [Term]
 id: FBcv:0000732
@@ -4775,8 +4775,8 @@ namespace: sex_qualifier
 def: "Expression is limited to mated males." [FBC:DOS]
 comment: May be used to qualify expression of phenotypes or of genes, transgenes etc.
 is_a: FBcv:0000307 ! male limited
-created_by: djs93
-creation_date: 2011-04-21T01:12:14Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:12:14Z xsd:dateTime
 
 [Term]
 id: FBcv:0000733
@@ -4785,8 +4785,8 @@ namespace: sex_qualifier
 def: "Expression is limited to virgin males." [FBC:DOS]
 comment: May be used to qualify expression of phenotypes or of genes, transgenes etc.
 is_a: FBcv:0000307 ! male limited
-created_by: djs93
-creation_date: 2011-04-21T01:13:00Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2011-04-21T01:13:00Z xsd:dateTime
 
 [Term]
 id: FBcv:0000735
@@ -4804,8 +4804,8 @@ namespace: allele_class
 def: "An allele that completely lacks function (i.e. whose gene productive is completely inactive) at high temperatures, but that retains at least some function at lower temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000688 ! amorphic allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000737
@@ -4814,8 +4814,8 @@ namespace: allele_class
 def: "An allele inferred to completely lack function at some temperatures (restrictive temperatures) but not others (permissive temperatures) from the observation that addition of extra copies in the genome has no effect on the phenotype at the restrictive temperatures. Most commonly, evidence takes the form of the observation that the phenotype of homozygotes (2 copies) is identical to that seen when the allele is in trans to a deletion of the gene (1 copy)." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000288 ! amorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000738
@@ -4823,8 +4823,8 @@ name: edited book
 namespace: pub_type
 def: "A publication that is not issued on a regular, ongoing basis containing separate articles or chapters (typically reviews) written by different authors on a single subject or related subjects, overseen by one or more editors." [FBC:SM]
 is_a: FBcv:0000652 ! compendium
-created_by: djs93
-creation_date: 2012-07-10T04:05:08Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-07-10T04:05:08Z xsd:dateTime
 
 [Term]
 id: FBcv:0000739
@@ -4833,8 +4833,8 @@ namespace: allele_class
 def: "An allele that completely lacks function (i.e. whose gene productive is completely inactive) at some temperatures, but not others." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000688 ! amorphic allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000740
@@ -4843,8 +4843,8 @@ namespace: allele_class
 def: "An allele inferred to completely lack function at low temperatures (restrictive temperatures) but not at high temperatures (permissive temperatures) from the observation that adding extra copies in the genome has no effect on the phenotype at the restrictive temperatures. Most commonly, evidence takes the form of the observation that the phenotype of homozygotes (2 copies) is identical to that seen when the allele is in trans to a deletion of the gene (1 copy)." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000288 ! amorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000741
@@ -4853,8 +4853,8 @@ namespace: allele_class
 def: "An allele inferred to completely lack function at high temperatures (restrictive temperatures) but not at low temperatures (permissive temperatures) from the observation that adding extra copies in the genome has no effect on the phenotype at the restrictive temperatures. Most commonly, evidence takes the form of the observation that the phenotype of homozygotes (2 copies) is identical to that seen when the allele is in trans to a deletion of the gene (1 copy)." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000288 ! amorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000742
@@ -4863,8 +4863,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to completely lack function at low temperatures (restrictive temperatures) but not at high temperatures (permissive temperatures)." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000689 ! amorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000743
@@ -4873,8 +4873,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to completely lack function at high temperatures (restrictive temperatures) but not at low temperatures (permissive temperatures)." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000689 ! amorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000744
@@ -4883,8 +4883,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to completely lack function at some temperatures (restrictive temperatures) but not at others (permissive temperatures)." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000689 ! amorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000745
@@ -4893,8 +4893,8 @@ namespace: allele_class
 def: "An allele that at some temperatures but not others either makes no functional gene product or makes reduced levels of a normally functioning gene product or makes a gene product with reduced activity compared to wild-type." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000287 ! loss of function allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000746
@@ -4903,8 +4903,8 @@ namespace: allele_class
 def: "An allele that at high temperatures but not low temperatures, either makes no functional gene product, makes reduced levels of a normally functioning gene product or makes a gene product with reduced activity compared to wild-type." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000287 ! loss of function allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000747
@@ -4921,8 +4921,8 @@ namespace: allele_class
 def: "An allele that at some temperatures but not others, either makes a normally functioning gene product but at higher levels or in a different spatial or temporal pattern to wild-type, or a product with increased or novel activity compared to wild-type." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000290 ! gain of function allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000749
@@ -4931,8 +4931,8 @@ namespace: allele_class
 def: "An allele that at high temperatures but not low temperatures, either makes a normally functioning gene product but at higher levels or in a different spatial or temporal pattern to wild-type, or a product with increased or novel activity compared to wild-type." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000290 ! gain of function allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000750
@@ -4949,8 +4949,8 @@ namespace: allele_class
 def: "An allele that, at some temperatures but not others, makes a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000690 ! hypomorphic allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000752
@@ -4959,8 +4959,8 @@ namespace: allele_class
 def: "An allele that makes a gene product that is functionally equivalent to wild-type but which at high temperatures is present in a lesser amount or with lowered activity, and that retains normal levels of expression or activity at low temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000690 ! hypomorphic allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000753
@@ -4977,8 +4977,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to have normal activity at some temperatures (permissive temperatures) but at other temperatures to make a gene product with normal function but in a lesser amount or with lowered activity (non-permissive temperatures). The genetic evidence must consist of an observation extra copies in the genome decrease the expressivity and/or penetrance of the phenotype at non-permissive temperatures. Most commonly this evidence takes the form of experiments showing that the homozygote (2 copies) has a weaker phenotype at non-permissive temperatures than the allele in trans to a deletion of the gene (1 copy))." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000289 ! hypomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000755
@@ -4987,8 +4987,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to have normal activity at high temperatures (permissive temperatures) but to make a gene product with normal function but in a lesser amount or with lowered activity at lower temperatures (non-permissive temperatures). The genetic evidence must consist of an observation extra copies in the genome decrease the expressivity and/or penetrance of the phenotype at non-permissive temperatures. Most commonly this evidence takes the form of experiments showing that the homozygote (2 copies) has a weaker phenotype at non-permissive temperatures than the allele in trans to a deletion of the gene (1 copy))." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000289 ! hypomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000756
@@ -4997,8 +4997,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to have normal activity at low temperatures (permissive temperatures) but to make a gene product with normal function but in a lesser amount or with lowered activity at higher temperatures (non-permissive temperatures). The genetic evidence must consist of an observation extra copies in the genome decrease the expressivity and/or penetrance of the phenotype at non-permissive temperatures. Most commonly this evidence takes the form of experiments showing that the homozygote (2 copies) has a weaker phenotype at non-permissive temperatures than the allele in trans to a deletion of the gene (1 copy))." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000289 ! hypomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000757
@@ -5007,8 +5007,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a normal gene product in normal amounts at some temperatures, but at other temperatures to make a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000691 ! hypomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000758
@@ -5017,8 +5017,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a normal gene product in normal amounts at high temperatures, but at lower temperatures to make a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000691 ! hypomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000759
@@ -5027,8 +5027,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a normal gene product in normal amounts at low temperatures, but at higher temperatures to make a gene product that is functionally equivalent to wild-type but in a lesser amount or with lowered activity." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000691 ! hypomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000760
@@ -5037,8 +5037,8 @@ namespace: allele_class
 def: "An allele that makes a gene product that is antagonistic to the function of the wild-type gene product at some temperatures, but not others." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000695 ! antimorphic allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000761
@@ -5047,8 +5047,8 @@ namespace: allele_class
 def: "An allele that makes a gene product that is antagonistic to the function of the wild-type gene product at high temperatures, but not at lower temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000695 ! antimorphic allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000762
@@ -5065,8 +5065,8 @@ namespace: allele_class
 def: "An allele inferred to make a gene product that is antagonistic to the wild-type gene product at some temperatures (restrictive temperatures) but not at others (permissive temperatures) from the observation that, at the non-permissive temperatures, the phenotype over a deficiency is stronger than that over a wild-type allele, which in turn is stronger than that in the presence of a duplication of the wild-type locus." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000292 ! antimorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000764
@@ -5075,8 +5075,8 @@ namespace: allele_class
 def: "An allele inferred to make a gene product that is antagonistic to the wild-type gene product at low temperatures (restrictive temperatures) but not at high temperatures (permissive temperatures) from the observation that, at the non-permissive temperatures, the phenotype over a deficiency is stronger than that over a wild-type allele, which in turn is stronger than that in the presence of a duplication of the wild-type locus." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000292 ! antimorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000765
@@ -5085,8 +5085,8 @@ namespace: allele_class
 def: "An allele inferred to make a gene product that is antagonistic to the wild-type gene product at high temperatures (restrictive temperatures) but not at lower temperatures (permissive temperatures) from the observation that, at the non-permissive temperatures, the phenotype over a deficiency is stronger than that over a wild-type allele, which in turn is stronger than that in the presence of a duplication of the wild-type locus." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000292 ! antimorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000766
@@ -5095,8 +5095,8 @@ namespace: allele_class
 def: "An allele that has been shown by molecular evidence to make a gene product that is antagonistic to the function of the wild-type gene product at some temperatures but not others." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000694 ! antimorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000767
@@ -5105,8 +5105,8 @@ namespace: allele_class
 def: "An allele that has been shown by molecular evidence to make a gene product that is antagonistic to the function of the wild-type gene product at low temperatures but not higher temperatures." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000694 ! antimorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000768
@@ -5115,8 +5115,8 @@ namespace: allele_class
 def: "An allele that has been shown by molecular evidence to make a gene product that is antagonistic to the function of the wild-type gene product at high temperatures but not lower temperatures." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000694 ! antimorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000769
@@ -5125,8 +5125,8 @@ namespace: allele_class
 def: "An allele that, at some temperatures but not others, makes a gene product with a novel function or expression pattern compared to wild-type." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000697 ! neomorphic allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000770
@@ -5135,8 +5135,8 @@ namespace: allele_class
 def: "An allele that, at some high temperatures but not lower temperatures, makes a gene product with a novel function or expression pattern compared to wild-type." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000697 ! neomorphic allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000771
@@ -5153,8 +5153,8 @@ namespace: allele_class
 def: "An allele that, is inferred to make a gene product with a novel function or expression pattern compared to wild-type at some temperatures (non-permissive temperatures) but not others (permissive temperatures) based on the evidence that the phenotype at the non-permissive temperature is unaffected by extra or fewer doses of the wild-type gene." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000291 ! neomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000773
@@ -5163,8 +5163,8 @@ namespace: allele_class
 def: "An allele that, is inferred to make a gene product with a novel function or expression pattern compared to wild-type at some low temperatures (non-permissive temperatures) but not higher temperatures (permissive temperatures), based on the evidence that the phenotype at the non-permissive temperature is unaffected by extra or fewer doses of the wild-type gene." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000291 ! neomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000774
@@ -5173,8 +5173,8 @@ namespace: allele_class
 def: "An allele that, is inferred to make a gene product with a novel function or expression pattern compared to wild-type at some high temperatures (non-permissive temperatures) but not lower temperatures (permissive temperatures), based on the evidence that the phenotype at the non-permissive temperature is unaffected by extra or fewer doses of the wild-type gene." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000291 ! neomorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000775
@@ -5183,8 +5183,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to produce a gene product with a novel function or expression pattern (compared to wild-type) at some temperatures but not others." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000692 ! neomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000776
@@ -5193,8 +5193,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to produce a gene product with a novel function or expression pattern (compared to wild-type) at low temperatures but not higher temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000692 ! neomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000777
@@ -5203,8 +5203,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to produce a gene product with a novel function or expression pattern (compared to wild-type) at high temperatures but not lower temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000692 ! neomorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000778
@@ -5213,8 +5213,8 @@ namespace: allele_class
 def: "An allele that, at some temperatures but not others, makes a gene product with normal function but at higher levels or with higher activity than in wild-type." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000696 ! hypermorphic allele
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:57:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:57:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0000779
@@ -5223,8 +5223,8 @@ namespace: allele_class
 def: "An allele that, at high temperatures but not lower temperatures, makes a gene product with normal function but at higher levels or with higher activity than in wild-type." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000696 ! hypermorphic allele
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:54:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:54:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000780
@@ -5241,8 +5241,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to make a normal gene product at increased levels or with increased activity compared to wild-type, where this increased amount or activity is present at some temperatures (non-permissive temperatures) but not others (permissive temperatures), and where the genetic evidence consists of the observation that extra copies in the genome increase the expressivity and/or penetrance of the phenotype at the non-permissive temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000293 ! hypermorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000782
@@ -5251,8 +5251,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to make a normal gene product at increased levels or with increased activity compared to wild-type, where this increased amount or activity is present at low temperatures (non-permissive temperatures) but not higher temperatures (permissive temperatures), and where the genetic evidence consists of the observation that extra copies in the genome increase the expressivity and/or penetrance of the phenotype at the non-permissive temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000293 ! hypermorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000783
@@ -5261,8 +5261,8 @@ namespace: allele_class
 def: "An allele inferred from genetic evidence to make a normal gene product at increased levels or with increased activity compared to wild-type, where this increased amount or activity is present at high temperatures (non-permissive temperatures) but not lower temperatures (permissive temperatures), and where the genetic evidence consists of the observation that extra copies in the genome increase the expressivity and/or penetrance of the phenotype at the non-permissive temperatures." [FBC:DOS, FlyBase:FBrf0002371, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000293 ! hypermorphic allele - genetic evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000784
@@ -5271,8 +5271,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a functionally wild-type gene product at increased levels or with increased activity where this increased expression or activity occurs at some temperatures but not others." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000693 ! hypermorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000310 ! temperature conditional
-created_by: djs93
-creation_date: 2012-03-22T03:55:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:55:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0000785
@@ -5281,8 +5281,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a functionally wild-type gene product at increased levels or with increased activity where this increased expression or activity occurs at low temperatures but not higher temperatures." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000693 ! hypermorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000312 ! cold sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:58:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:58:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0000786
@@ -5291,8 +5291,8 @@ namespace: allele_class
 def: "An allele shown by molecular evidence to make a functionally wild-type gene product at increased levels or with increased activity where this increased expression or activity occurs at high temperatures but not lower temperatures." [FBC:DOS, FlyBase:FBrf0049147]
 intersection_of: FBcv:0000693 ! hypermorphic allele - molecular evidence
 intersection_of: conditionality FBcv:0000311 ! heat sensitive
-created_by: djs93
-creation_date: 2012-03-22T03:59:43Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-03-22T03:59:43Z xsd:dateTime
 
 [Term]
 id: FBcv:0000787
@@ -5302,8 +5302,8 @@ def: "A publication issued on a regular, ongoing basis containing separate resea
 synonym: "Periodicals" RELATED [MeSH:D020492]
 xref: MeSH:D020492
 is_a: FBcv:0000652 ! compendium
-created_by: djs93
-creation_date: 2012-07-10T04:08:06Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-07-10T04:08:06Z xsd:dateTime
 
 [Term]
 id: FBcv:0000788
@@ -5312,8 +5312,8 @@ namespace: pub_type
 def: "A work consisting of a news item appearing in a general-interest newspaper or other general news periodical, containing information of current and timely interest in the field of medicine or science." [FBC:SM, MeSH:D018431]
 xref: MeSH:D018431
 is_a: FBcv:0000189 ! publication class
-created_by: djs93
-creation_date: 2012-07-10T04:17:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-07-10T04:17:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0000789
@@ -5321,8 +5321,8 @@ name: sequence record
 namespace: pub_type
 def: "A record of a nucleotide or protein sequence in some standard format." [FBC:SM]
 is_a: FBcv:0000189 ! publication class
-created_by: djs93
-creation_date: 2012-07-10T05:42:47Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-07-10T05:42:47Z xsd:dateTime
 
 [Term]
 id: FBcv:0000790
@@ -5331,8 +5331,8 @@ namespace: pub_type
 def: "Work consisting of a structured file of information or a set of logically related data stored and retrieved using computer-based means." [FBC:SM, MeSH:D019991]
 xref: MeSH:D019991
 is_a: FBcv:0000189 ! publication class
-created_by: djs93
-creation_date: 2012-07-13T02:06:57Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-07-13T02:06:57Z xsd:dateTime
 
 [Term]
 id: FBcv:0000793
@@ -5340,8 +5340,8 @@ name: progressive
 namespace: temporal_qualifier
 def: "A phenotype that becomes more severe with age." [FBC:DOS]
 is_a: FBcv:0000176 ! temporal qualifier
-created_by: djs93
-creation_date: 2012-10-10T12:02:35Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-7073-9172
+property_value: http://purl.org/dc/terms/date 2012-10-10T12:02:35Z xsd:dateTime
 
 [Term]
 id: FBcv:0000797
@@ -5465,8 +5465,8 @@ namespace: disease_qualifier
 def: "Qualifier that describes aspects of genetic models of disease." [FBC:MMC]
 subset: do_not_annotate
 is_a: FBcv:0000005 ! qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003001
@@ -5475,8 +5475,8 @@ namespace: disease_qualifier
 def: "Makes a condition better." [FBC:ST]
 comment: The 'ameliorates' term is used in FlyBase disease annotation when an allele interacts to remove or reduce the severity of the disease phenotype associated with a given disease model (FBC:ST).
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003002
@@ -5485,8 +5485,8 @@ namespace: disease_qualifier
 def: "Contrary to expectation, does not make a condition better." [FBC:ST]
 comment: The 'DOES NOT ameliorate' term is used in FlyBase disease annotation when an allele is expected to remove or reduce the severity of the disease phenotype associated with a given disease model but fails to do so.
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003003
@@ -5495,8 +5495,8 @@ namespace: disease_qualifier
 def: "Contrary to expectation, does not make a condition worse." [FBC:ST]
 comment: The 'DOES NOT exacerbate' term is used in FlyBase disease annotation when an allele is expected to makes the disease phenotype associated with a given disease model more severe but fails to do so (FBC:ST).
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003004
@@ -5505,8 +5505,8 @@ namespace: disease_qualifier
 def: "Contrary to expectation, characteristics associated with a given condition are not recapitulated in a different system." [FBC:ST]
 comment: The 'DOES NOT model' term is used in FlyBase disease annotation when an allele is expected to recapitulate one or more aspects of a particular human disease phenotype in Drosophila but fails to do so (FBC:ST).
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003005
@@ -5515,8 +5515,8 @@ namespace: disease_qualifier
 def: "Makes a condition worse." [FBC:ST]
 comment: The 'exacerbates' term is used in FlyBase disease annotation when an allele interacts to make the disease phenotype associated with a given disease model more severe (FBC:ST).
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003006
@@ -5525,8 +5525,8 @@ namespace: disease_qualifier
 def: "Characteristics associated with a given condition recapitulated in a different system." [FBC:ST]
 comment: The 'model of' term is used in FlyBase disease annotation when alleles (typically of fly or human genes) recapitulate one or more aspect of a human disease phenotype in Drosophila (FBC:ST).
 is_a: FBcv:0003000 ! disease qualifier
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003007
@@ -5535,8 +5535,8 @@ namespace: origin_of_mutation
 def: "Sequence change induced by a cleavage event that is caused by an endonuclease that recognizes and cleaves specific sequences in double stranded DNA causing double-strand breaks (DSB)." [FlyBase:FBrf0202435]
 synonym: "change induced by site specific cleavage" EXACT []
 is_a: FBcv:0000452 ! origin of mutation
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003008
@@ -5546,8 +5546,8 @@ def: "Sequence change caused by a cleavage of a specific DNA sequence induced by
 synonym: "change induced by CRISPR/Cas9 endonuclease cleavage" EXACT []
 synonym: "CRISPR/Cas9 endonuclease" RELATED []
 is_a: FBcv:0003007 ! site specific cleavage
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003009
@@ -5557,8 +5557,8 @@ def: "Sequence change caused by the cleavage of specific DNA sequences by transc
 synonym: "change induced by TALE endonuclease cleavage" EXACT []
 synonym: "TALE endonuclease" RELATED []
 is_a: FBcv:0003007 ! site specific cleavage
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003010
@@ -5567,8 +5567,8 @@ namespace: origin_of_mutation
 def: "Sequence change caused by a site specific recombination catalyzed by the serine recombinase phiC31 integrase that recognizes a minimal high-efficiency attP recognition site of 39 base pairs and a minimal high-efficiency attB recognition site of 34 base pairs. The attP and attB sites contain imperfect inverted repeats flanking a short recombination core (TTG) that provides directionality." [FlyBase:FBrf0174693, FlyBase:FBrf0201927, UniProt:Q9T221]
 synonym: "change induced by phiC31 integrase recombination" EXACT []
 is_a: FBcv:0000478 ! site specific recombination
-created_by: mmc46
-creation_date: 2014-03-27T11:07:29Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-27T11:07:29Z xsd:dateTime
 
 [Term]
 id: FBcv:0003011
@@ -5577,8 +5577,8 @@ namespace: group_descriptor
 def: "Descriptor that relates aspects of the grouping of genes or gene products." [FBC:MMC]
 subset: do_not_annotate
 is_a: FBcv:0000013 ! descriptor
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003012
@@ -5586,8 +5586,8 @@ name: gene or gene product group
 namespace: group_descriptor
 def: "Genes or gene products that are acknowledged to form a natural biological group." [FBC:SM]
 is_a: FBcv:0003011 ! group descriptor
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003013
@@ -5595,8 +5595,8 @@ name: gene array group
 namespace: group_descriptor
 def: "Two or more genes contiguously arranged where the individual genes are either identical in sequence, or essentially so (SO:0005851)." [FBC:SM, SO:ma]
 is_a: FBcv:0003012 ! gene or gene product group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003014
@@ -5604,8 +5604,8 @@ name: functional group
 namespace: group_descriptor
 def: "Genes whose products share a common biological and/or molecular function." [FBC:SM]
 is_a: FBcv:0003012 ! gene or gene product group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003015
@@ -5613,8 +5613,8 @@ name: gene complex group
 namespace: group_descriptor
 def: "Genes with the same location on the chromosome and whose products have a similar function." [FBC:SM, http://www.sdbonline.org/fly/aignfam/ensplitc.htm]
 is_a: FBcv:0003014 ! functional group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003016
@@ -5622,8 +5622,8 @@ name: protein complex group
 namespace: group_descriptor
 def: "Genes whose protein products form a macromolecular complex (GO:0043234)." [FBC:SM, GOC:go_curators]
 is_a: FBcv:0003014 ! functional group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003017
@@ -5631,8 +5631,8 @@ name: pathway group
 namespace: group_descriptor
 def: "Genes whose products act in a specified signal transduction or metabolic pathway." [FBC:SM]
 is_a: FBcv:0003014 ! functional group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003018
@@ -5640,8 +5640,8 @@ name: process group
 namespace: group_descriptor
 def: "Genes whose products act in a specified biological process." [FBC:SM]
 is_a: FBcv:0003014 ! functional group
-created_by: mmc46
-creation_date: 2014-03-28T15:23:42Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-03-28T15:23:42Z xsd:dateTime
 
 [Term]
 id: FBcv:0003019
@@ -5650,8 +5650,8 @@ namespace: origin_of_mutation
 def: "Mutation caused by the transposable activity caused by the I-element, a non-LTR retrotransposon. The I-element is 5371 base pairs long. Mobilization is induced by the activity of the I-element transposase." [FlyBase:FBrf0202435]
 synonym: "mutation induced by I-element activity" EXACT []
 is_a: FBcv:0000483 ! transposable element activity
-created_by: mmc46
-creation_date: 2014-09-16T13:30:48Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-09-16T13:30:48Z xsd:dateTime
 
 [Term]
 id: FBcv:0003020
@@ -5660,16 +5660,16 @@ namespace: origin_of_mutation
 def: "Mutation caused by the transposable activity caused by the Stalker element, a LTR retrotransposon. Mobilization is induced by the activity of the stalker element transposase." [FlyBase:FBrf0202435]
 synonym: "mutation induced by Stalker element activity" EXACT []
 is_a: FBcv:0000483 ! transposable element activity
-created_by: mmc46
-creation_date: 2014-09-16T13:30:48Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2014-09-16T13:30:48Z xsd:dateTime
 
 [Term]
 id: FBcv:0003021
 name: dataset descriptor
 def: "Term that describes a dataset." [FBC:GD]
 is_a: FBcv:0000013 ! descriptor
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003022
@@ -5677,8 +5677,8 @@ name: dataset entity type
 namespace: dataset_entity_type
 def: "Term that specifies the dataset component type." [FBC:GD]
 is_a: FBcv:0003021 ! dataset descriptor
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003023
@@ -5686,8 +5686,8 @@ name: project
 namespace: dataset_entity_type
 def: "A set of biological data from a single study. Corresponds to the NCBI bioproject, GEO series or SRA study." [FBC:GD]
 is_a: FBcv:0003022 ! dataset entity type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003024
@@ -5695,8 +5695,8 @@ name: biosample
 namespace: dataset_entity_type
 def: "Biological source material characterized by an experiment." [FBC:GD]
 is_a: FBcv:0003022 ! dataset entity type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003025
@@ -5704,8 +5704,8 @@ name: assay
 namespace: dataset_entity_type
 def: "Quantitative or qualitative assessment of biological source material to measure some attribute." [FBC:GD]
 is_a: FBcv:0003022 ! dataset entity type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003026
@@ -5713,8 +5713,8 @@ name: result
 namespace: dataset_entity_type
 def: "Analysis of raw data generated by an assay(s) that makes some conclusion." [FBC:GD]
 is_a: FBcv:0003022 ! dataset entity type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003027
@@ -5722,16 +5722,16 @@ name: reagent collection
 namespace: dataset_entity_type
 def: "A collection of material reagents." [FBC:GD]
 is_a: FBcv:0003022 ! dataset entity type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003028
 name: dataset data type
 def: "The data type content of a dataset." [FBC:GD]
 is_a: FBcv:0003021 ! dataset descriptor
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003029
@@ -5739,8 +5739,8 @@ name: project type
 namespace: project_type
 def: "The type of project as characterized its data content." [FBC:GD]
 is_a: FBcv:0003028 ! dataset data type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003030
@@ -5748,8 +5748,8 @@ name: umbrella project
 namespace: project_type
 def: "A project that groups together related sub-projects." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003031
@@ -5757,8 +5757,8 @@ name: genome
 namespace: project_type
 def: "A project that characterizes an organism's genome sequence." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003032
@@ -5766,8 +5766,8 @@ name: genome variation
 namespace: project_type
 def: "A project that characterizes the intraspecific variation of an organism's genome." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003033
@@ -5775,8 +5775,8 @@ name: genome binding
 namespace: project_type
 def: "A project that characterizes the occupancy profile of a factor that binds directly or indirectly to the genome." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003034
@@ -5784,8 +5784,8 @@ name: transcriptome
 namespace: project_type
 def: "A project that characterizes the set of transcribed RNA sequences expressed by the genome." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003035
@@ -5793,8 +5793,8 @@ name: proteome
 namespace: project_type
 def: "A project that characterizes the set of proteins expressed in an organism." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003036
@@ -5802,8 +5802,8 @@ name: interactome
 namespace: project_type
 def: "A project that characterizes the set of inter-molecular interactions in an organism." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003037
@@ -5811,8 +5811,8 @@ name: metabolome
 namespace: project_type
 def: "A project that characterizes the set of small molecules in an organism." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003038
@@ -5820,8 +5820,8 @@ name: phenotypic screen
 namespace: project_type
 def: "A project that searches for the genes responsible for a particular observable trait." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003039
@@ -5829,8 +5829,8 @@ name: chemical screen
 namespace: project_type
 def: "A project that searches for chemicals, natural or synthetic, that elicit some biological effect." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003040
@@ -5838,8 +5838,8 @@ name: gene model annotation
 namespace: project_type
 def: "A project that constructs models describing the set of transcripts and polypeptides encoded by some group of genes." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003041
@@ -5847,8 +5847,8 @@ name: phylogenetic analysis
 namespace: project_type
 def: "A project that reconstructs the evolutionary history of a group of genes or organisms." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003042
@@ -5856,8 +5856,8 @@ name: reagent
 namespace: project_type
 def: "A project that describes a large material resource that is accessible to the community." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003043
@@ -5865,8 +5865,8 @@ name: other
 namespace: project_type
 def: "A project type that is not described by other more specific terms." [FBC:GD]
 is_a: FBcv:0003029 ! project type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003044
@@ -5874,8 +5874,8 @@ name: biosample type
 namespace: biosample_type
 def: "The type of biosample as characterized by its biological source material." [FBC:GD]
 is_a: FBcv:0003028 ! dataset data type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003045
@@ -5883,8 +5883,8 @@ name: whole organism
 namespace: biosample_type
 def: "A biosample that comprises the whole animal." [FBC:GD]
 is_a: FBcv:0003044 ! biosample type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003046
@@ -5892,8 +5892,8 @@ name: tissue
 namespace: biosample_type
 def: "A biosample derived from a multicellular structure comprising similar cells with some specific function, typically isolated by dissection." [FBC:GD]
 is_a: FBcv:0003044 ! biosample type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003047
@@ -5901,8 +5901,8 @@ name: isolated cells
 namespace: biosample_type
 def: "A biosample containing dissociated cells isolated from the organism, typically isolated by affinity capture or sorting methods." [FBC:GD]
 is_a: FBcv:0003044 ! biosample type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003048
@@ -5910,8 +5910,8 @@ name: primary cell line
 namespace: biosample_type
 def: "A biosample consisting of cells that were isolated from animal tissue and cultured in vitro for a limited amount of time." [FBC:GD]
 is_a: FBcv:0003044 ! biosample type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003049
@@ -5919,8 +5919,8 @@ name: immortalized cell line
 namespace: biosample_type
 def: "A biosample consisting of cells isolated from animal tissue that have acquired the ability to proliferate indefinitely." [FBC:GD]
 is_a: FBcv:0003044 ! biosample type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003050
@@ -5928,8 +5928,8 @@ name: assay type
 namespace: assay_type
 def: "The type of assay as characterized by its data content." [FBC:GD]
 is_a: FBcv:0003028 ! dataset data type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003051
@@ -5937,8 +5937,8 @@ name: CAGE-Seq
 namespace: assay_type
 def: "An assay of 5' capped transcripts, using CAGE to biotinylate and isolate the 7-methylguanosine cap, with subsequent characterization by high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003052
@@ -5946,8 +5946,8 @@ name: ChIP-chip
 namespace: assay_type
 def: "A genome binding assay of some factor as characterized by chromatin immunoprecipitation (ChIP) of that factor and analysis of co-purifying DNA fragments using genome tiling array." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003053
@@ -5955,8 +5955,8 @@ name: ChIP-Seq
 namespace: assay_type
 def: "A genome binding assay of some factor as characterized by chromatin immunoprecipitation (ChIP) of that factor and high-throughput sequencing of co-purifying DNA fragments." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003054
@@ -5964,8 +5964,8 @@ name: CLiP-Seq
 namespace: assay_type
 def: "An RNA binding assay of some protein as characterized by cross-linking immunoprecipitation (CLiP) and high-throughput sequencing of co-purifying RNA fragments." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003055
@@ -5973,8 +5973,8 @@ name: DamID-chip
 namespace: assay_type
 def: "A genome binding assay of some protein as characterized by creating a fusion to DNA adenine methyltransferase and analysis of methylated DNA sequences by genome tiling array." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003056
@@ -5982,8 +5982,8 @@ name: DamID-Seq
 namespace: assay_type
 def: "A genome binding assay of some protein as characterized by creating a fusion to DNA adenine methyltransferase and analysis of methylated DNA sequences by high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003057
@@ -5991,8 +5991,8 @@ name: DNase-chip
 namespace: assay_type
 def: "An assay that characterizes the genome's DNase hypersensitivity using genome tiling array." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003058
@@ -6000,8 +6000,8 @@ name: DNase-Seq
 namespace: assay_type
 def: "An assay that characterizes the genome's DNase hypersensitivity using high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003059
@@ -6009,8 +6009,8 @@ name: FAIRE-Seq
 namespace: assay_type
 def: "An assay that characterizes transcriptional regulatory elements using formaldehyde-assisted isolation of regulatory elements (FAIRE) and high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003060
@@ -6018,8 +6018,8 @@ name: GRO-Seq
 namespace: assay_type
 def: "An assay that maps the genome-wide position, orientation and amount of transcriptionally engaged RNA polymerase by global run-on sequencing." [PMID:19056941]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003061
@@ -6027,8 +6027,8 @@ name: MNase-chip
 namespace: assay_type
 def: "An assay that maps nucleosome positions by using micrococcal nuclease to cleave linker DNA with the subsequent isolation of mononucleosomal DNA fragments that are characterized by genome tiling array." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003062
@@ -6036,8 +6036,8 @@ name: MNase-Seq
 namespace: assay_type
 def: "An assay that maps nucleosome positions by using micrococcal nuclease to cleave linker DNA with the subsequent isolation of mononucleosomal DNA fragments that are characterized by high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003063
@@ -6045,8 +6045,8 @@ name: RAMPAGE-Seq
 namespace: assay_type
 def: "An assay of 5'-capped transcripts using the orthogonal approaches of reverse transcriptase template-switching and cap-trapping, with subsequent characterization by high-throughput sequencing." [PMID:22936248]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003064
@@ -6054,8 +6054,8 @@ name: Repli-Seq
 namespace: assay_type
 def: "An assay mapping genomic replication patterns by labeling newly synthesized DNA in vivo with 5-bromo-2-deoxyuridine (BrdU), with subsequent affinity purification and characterization by high-throughput sequencing." [PMID:19966280]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003065
@@ -6063,8 +6063,8 @@ name: Ribo-Seq
 namespace: assay_type
 def: "Ribosome profiling, an assay in which mRNA fragments protected by ribosomes are isolated and characterized by high-throughput sequencing." [PMID:22056041]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003066
@@ -6072,8 +6072,8 @@ name: RIP-Seq
 namespace: assay_type
 def: "An assay in which a factor is immunoprecipitated and the associated RNA sequences are characterized by high-throughput sequencing." [PMID:21051541]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003067
@@ -6081,8 +6081,8 @@ name: RNA expression microarray
 namespace: assay_type
 def: "Measurement of global transcript abundance by hybridization of cDNA to an oligonucleotide array, in which the array contains a set of probes designed with complementarity to each annotated transcript." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003068
@@ -6090,8 +6090,8 @@ name: RNA-Seq
 namespace: assay_type
 def: "A quantitative method for mapping transcribed regions, in which complementary DNA fragments are subjected to high-throughput sequencing." [PMID:18451266]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003069
@@ -6099,8 +6099,8 @@ name: RNA tiling array
 namespace: assay_type
 def: "Measurement of transcribed regions across the genome by hybridization of cDNA to an oligonucleotide array, in which the genome is represented by oligonucleotides at regularly spaced intervals." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003070
@@ -6108,8 +6108,8 @@ name: short RNA-Seq
 namespace: assay_type
 def: "An assay characterizing of small RNA species 17-35 nt in size by high-throughput sequencing." [FBC:GD]
 is_a: FBcv:0003068 ! RNA-Seq
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003071
@@ -6117,8 +6117,8 @@ name: protein mass spectrometry
 namespace: assay_type
 def: "An assay that identifies and characterizes of proteins and their post-translational modifications by mass spectrometry." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003072
@@ -6126,8 +6126,8 @@ name: lipid mass spectrometry
 namespace: assay_type
 def: "An assay that identifies and characterizes lipids by mass spectrometry." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003073
@@ -6135,8 +6135,8 @@ name: carbohydrate mass spectrometry
 namespace: assay_type
 def: "An assay that identifies and characterizes complex carbohydrates by mass spectrometry." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003074
@@ -6144,8 +6144,8 @@ name: metabolite mass spectrometry
 namespace: assay_type
 def: "An assay that identifies and characterizes small metabolites by mass spectrometry." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003075
@@ -6153,8 +6153,8 @@ name: affinity purification and mass spectrometry
 namespace: assay_type
 def: "An assay that identifies the molecules that interact with a particular bait factor by mass spectrometry." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003076
@@ -6162,8 +6162,8 @@ name: two hybrid screen
 namespace: assay_type
 def: "An assay that tests proteins pairwise for interaction by fusing each to separate, complementary domains of some protein, usually a transcription factor. Upon interaction, the proximity of the complementary domains generates reporter activity." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003077
@@ -6171,8 +6171,8 @@ name: RNAi screen
 namespace: assay_type
 def: "An assay that uses a panel of RNA interference (RNAi) reagents to systematically knockdown a large set of genes, one at a time, to identify those that are involved in some biological process." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003078
@@ -6180,8 +6180,8 @@ name: deficiency screen
 namespace: assay_type
 def: "An assay that uses a panel of deficiencies to systematically delete large segments of the genome to identify those segments that are involved in some biological process." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003079
@@ -6189,8 +6189,8 @@ name: genetic screen
 namespace: assay_type
 def: "An assay that uses a large set of mutations to identify genes that are involved in some biological process." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003080
@@ -6198,8 +6198,8 @@ name: comparative genomic hybridization by array
 namespace: assay_type
 def: "An assay that characterizes copy number variation of the genome in a sample using genome tiling array." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003081
@@ -6207,8 +6207,8 @@ name: whole genome shotgun sequencing
 namespace: assay_type
 def: "An assay of genomic sequence that generates a large number of random genomic sequences, typically derived from paired-end sequencing of genomic fragments, that together give a complete (albeit scrambled) representation of the entire genome." [FBC:GD]
 is_a: FBcv:0003050 ! assay type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003082
@@ -6216,8 +6216,8 @@ name: result type
 namespace: result_type
 def: "The type of result as characterized by its data content." [FBC:GD]
 is_a: FBcv:0003028 ! dataset data type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003083
@@ -6225,8 +6225,8 @@ name: genetic map
 namespace: result_type
 def: "A result that maps the relative position of genetic markers, where distances are measured by recombination frequency." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003084
@@ -6234,8 +6234,8 @@ name: physical map
 namespace: result_type
 def: "A result that maps the relative position of genes and other sequence landmarks." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003085
@@ -6243,8 +6243,8 @@ name: whole genome shotgun assembly
 namespace: result_type
 def: "A result in which a collection of whole genome shotgun sequences is combined to build successively larger contigs." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003086
@@ -6252,8 +6252,8 @@ name: genome assembly
 namespace: result_type
 def: "The result of reconstruction of the genome achieved by aligning and merging smaller fragments." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003087
@@ -6261,8 +6261,8 @@ name: reference genome assembly
 namespace: result_type
 def: "The result of extensive sequence alignment and merging to produce a genome assembly that serves as the current reference for a particular organism." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003088
@@ -6270,8 +6270,8 @@ name: gene expression profile
 namespace: result_type
 def: "A result that provides the expression values for all (or some subset) of genes in a given biological sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003089
@@ -6279,8 +6279,8 @@ name: RNA-seq profile
 namespace: result_type
 def: "A result that profiles expressed RNA-seq sequences along genome." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003090
@@ -6288,8 +6288,8 @@ name: genome binding profile
 namespace: result_type
 def: "A result that profiles the genome occupancy for some factor." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003091
@@ -6297,8 +6297,8 @@ name: mRNA translation profile
 namespace: result_type
 def: "A result of Ribo-seq analysis that profiles ribosome protected sequences along the genome." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003092
@@ -6306,8 +6306,8 @@ name: TSS identification
 namespace: result_type
 def: "An analysis that results in the identification of discrete transcription start site regions." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003093
@@ -6315,8 +6315,8 @@ name: poly(A) site identification
 namespace: result_type
 def: "An analysis that results in the identification of discrete polyadenylation sites." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003094
@@ -6324,8 +6324,8 @@ name: exon junction identification
 namespace: result_type
 def: "An analysis that results in the identification of discrete exon junctions." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003095
@@ -6333,8 +6333,8 @@ name: editing site identification
 namespace: result_type
 def: "An analysis that results in the identification of discrete A-to-I RNA editing sites." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003096
@@ -6342,8 +6342,8 @@ name: binding site identification
 namespace: result_type
 def: "An analysis that results in the identification of discrete DNA or RNA binding sites." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003097
@@ -6351,8 +6351,8 @@ name: differential gene expression analysis
 namespace: result_type
 def: "An analysis that results from the comparison of expression profiles for different conditions to identify genes that are regulated by those conditions." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003098
@@ -6360,8 +6360,8 @@ name: expression clustering
 namespace: result_type
 def: "The analysis of a gene expression profiles to define sets of genes that share similar expression characteristics." [FBC:GD]
 is_a: FBcv:0003108 ! analysis
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003099
@@ -6369,8 +6369,8 @@ name: expression cluster
 namespace: result_type
 def: "A result that represents a set of genes that share similar expression characteristics across some set of conditions." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003100
@@ -6378,8 +6378,8 @@ name: gene list
 namespace: result_type
 def: "A result that represents a set of genes that have some shared characteristic." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003101
@@ -6387,8 +6387,8 @@ name: protein-protein interaction
 namespace: result_type
 def: "A result that represents a set of protein-protein interactions for a given sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003102
@@ -6396,8 +6396,8 @@ name: RNA-protein interaction
 namespace: result_type
 def: "A result that represents a set of RNA-protein interactions for a given sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003103
@@ -6405,8 +6405,8 @@ name: RNA-RNA interaction
 namespace: result_type
 def: "A result that represents a set of RNA-RNA interactions for a given sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003104
@@ -6414,8 +6414,8 @@ name: metabolite profile
 namespace: result_type
 def: "A result that represents a set of small molecules identified for a given sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003105
@@ -6423,8 +6423,8 @@ name: phenotypic profile
 namespace: result_type
 def: "A result that represents the range of phenotypes obtained for a set of genetic perturbations." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003106
@@ -6432,8 +6432,8 @@ name: genomic copy number profile
 namespace: result_type
 def: "A result that represents the copy number variation across the genome for a given sample." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003107
@@ -6441,8 +6441,8 @@ name: liftover file
 namespace: result_type
 def: "A result that represents the mapping of coordinates between two different genome assemblies for a given species." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003108
@@ -6450,8 +6450,8 @@ name: analysis
 namespace: result_type
 def: "A result that is produced from the detailed examination of data to come to some conclusion." [FBC:GD]
 is_a: FBcv:0003082 ! result type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003109
@@ -6459,8 +6459,8 @@ name: reagent collection type
 namespace: reagent_collection_type
 def: "The type of reagent collection as characterized by the material resources comprised by the collection." [FBC:GD]
 is_a: FBcv:0003028 ! dataset data type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003110
@@ -6468,8 +6468,8 @@ name: aberration stock collection
 namespace: reagent_collection_type
 def: "A collection of large chromosomal aberrations, available as fly stocks, which may include duplications, deletions, inversions or translocations." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003111
@@ -6477,8 +6477,8 @@ name: allele collection
 namespace: reagent_collection_type
 def: "A collection of alleles that are available as fly stocks." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003112
@@ -6486,8 +6486,8 @@ name: cDNA library
 namespace: reagent_collection_type
 def: "A collection of cDNAs available as plasmids." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003113
@@ -6495,8 +6495,8 @@ name: construct collection
 namespace: reagent_collection_type
 def: "A collection of transgenic constructs that are available as fly stocks." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003114
@@ -6504,8 +6504,8 @@ name: dsRNA amplicon collection
 namespace: reagent_collection_type
 def: "A collection of PCR products used for the synthesis of double-stranded RNA to induce RNA-interference." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003115
@@ -6513,8 +6513,8 @@ name: RNAi construct collection
 namespace: reagent_collection_type
 def: "A collection of transgenic constructs, available as fly stocks, designed to target gene knockdown by RNA-interference." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003116
@@ -6522,8 +6522,8 @@ name: genomic clone collection
 namespace: reagent_collection_type
 def: "A collection of genomic DNA clones available as plasmids. This may include BAC, YAC, fosmid, cosmid and P1 clone collections." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003117
@@ -6531,8 +6531,8 @@ name: fly strain collection
 namespace: reagent_collection_type
 def: "A collection of wild-type fly strains." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003118
@@ -6540,8 +6540,8 @@ name: transgenic insertion collection
 namespace: reagent_collection_type
 def: "A collection of transgenic construct insertions available as fly stocks." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003119
@@ -6549,8 +6549,8 @@ name: TE insertion stock collection
 namespace: reagent_collection_type
 def: "A collection of transposable element insertions available as fly stocks." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003120
@@ -6558,16 +6558,16 @@ name: microarray library
 namespace: reagent_collection_type
 def: "A collection of hybridization targets on a microarray." [FBC:GD]
 is_a: FBcv:0003109 ! reagent collection type
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003121
 name: dataset attribute
 def: "A descriptor that describes some aspect of a dataset." [FBC:GD]
 is_a: FBcv:0003021 ! dataset descriptor
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003122
@@ -6575,8 +6575,8 @@ name: project attribute
 namespace: project_attribute
 def: "A descriptor that describes some aspect of a project." [FBC:GD]
 is_a: FBcv:0003121 ! dataset attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003123
@@ -6584,8 +6584,8 @@ name: study design
 namespace: project_attribute
 def: "The aim of the project investigation, as defined by the key variables in the set of experiments." [FBC:GD]
 is_a: FBcv:0003122 ! project attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003124
@@ -6593,8 +6593,8 @@ name: species study
 namespace: project_attribute
 def: "A project study design that aims to compare different species." [FBC:GD]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003125
@@ -6602,8 +6602,8 @@ name: strain study
 namespace: project_attribute
 def: "A project study design that aims to compare different wild-type strains for a given species." [FBC:GD]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003126
@@ -6611,8 +6611,8 @@ name: sex study
 namespace: project_attribute
 def: "A project study design that aims to characterize the biological mechanisms responsible for the development or maintenance of the sex-related properties of an organism." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003127
@@ -6620,8 +6620,8 @@ name: developmental stage study
 namespace: project_attribute
 def: "A project study design investigating the biological mechanisms responsible for the control or maintenance of development." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003128
@@ -6629,8 +6629,8 @@ name: circadian rhythm study
 namespace: project_attribute
 def: "A project study design investigating the biological mechanisms responsible for the control or maintenance of circadian rhythm." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003129
@@ -6638,8 +6638,8 @@ name: cell cycle study
 namespace: project_attribute
 def: "A project study design investigating the biological mechanisms of the cell responsible for maintaining or controlling aspects of the cell cycle." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003130
@@ -6647,8 +6647,8 @@ name: tissue type study
 namespace: project_attribute
 def: "A project study design investigating the biological mechanisms of intact or dissected tissues in order to understand their form or function." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003131
@@ -6656,8 +6656,8 @@ name: cell type study
 namespace: project_attribute
 def: "A project study design involving the use of cultured or extracted cells with an investigative focus of studying a cellular property." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003132
@@ -6665,8 +6665,8 @@ name: subcellular component study
 namespace: project_attribute
 def: "A project study design examining subcellular components of cells including organelles, the nucleus, or any other grouping of intra- or extracellular material." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003133
@@ -6674,8 +6674,8 @@ name: gene study
 namespace: project_attribute
 def: "A project study design in which the goal of the study is to examine properties of a specific gene or set of genes." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003134
@@ -6683,8 +6683,8 @@ name: biotic stimulus study
 namespace: project_attribute
 def: "A project study design investigating the effects of a biotic stimulus on some aspect of an organism." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003135
@@ -6692,8 +6692,8 @@ name: chemical stimulus study
 namespace: project_attribute
 def: "A project study design investigating the effects of a chemical stimulus on some aspect of an organism." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003136
@@ -6701,8 +6701,8 @@ name: physical stimulus study
 namespace: project_attribute
 def: "A project study design investigating the effects of a physical stimulus on some aspect of an organism." [FBC:CT]
 is_a: FBcv:0003123 ! study design
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003137
@@ -6710,8 +6710,8 @@ name: biosample attribute
 namespace: biosample_attribute
 def: "Characteristics pertaining to the growth conditions, treatments and tissue isolation methods used to generate and obtain a biosample." [FBC:GD]
 is_a: FBcv:0003121 ! dataset attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003138
@@ -6719,8 +6719,8 @@ name: biosample scope
 namespace: biosample_attribute
 def: "The scope and purity of a biosample, ranging from single cell to environmental sample." [http://www.ncbi.nlm.nih.gov/books/NBK54364/]
 is_a: FBcv:0003137 ! biosample attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003139
@@ -6728,8 +6728,8 @@ name: single cell sample
 namespace: biosample_attribute
 def: "A biosample that is derived from only a single cell." [FBC:CT]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003140
@@ -6737,8 +6737,8 @@ name: single individual sample
 namespace: biosample_attribute
 def: "A biosample that is derived from one individual." [FBC:CT]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003141
@@ -6746,8 +6746,8 @@ name: multi-individual sample
 namespace: biosample_attribute
 def: "A biosample that is derived from multiple individuals." [FBC:CT]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003142
@@ -6755,8 +6755,8 @@ name: multispecies sample
 namespace: biosample_attribute
 def: "A biosample that is derived from multiple species." [FBC:CT]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003143
@@ -6764,8 +6764,8 @@ name: environmental
 namespace: biosample_attribute
 def: "A biosample derived from an environmental sample for which the species content is unknown." [http://www.ncbi.nlm.nih.gov/books/NBK54364/]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003144
@@ -6773,8 +6773,8 @@ name: artificial
 namespace: biosample_attribute
 def: "A biosample that was synthesized in a laboratory." [http://www.ncbi.nlm.nih.gov/books/NBK54364/]
 is_a: FBcv:0003138 ! biosample scope
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003145
@@ -6782,8 +6782,8 @@ name: wild caught
 namespace: biosample_attribute
 def: "A sample that originated from a wild caught population and is considered true wild type." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003146
@@ -6791,8 +6791,8 @@ name: growth condition
 namespace: biosample_attribute
 def: "Growth conditions and treatments used to culture the organism prior to biosample isolation." [FBC:GD]
 is_a: FBcv:0003137 ! biosample attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003147
@@ -6800,8 +6800,8 @@ name: trait selection
 namespace: biosample_attribute
 def: "An inbred strain is subjected to artificial laboratory selection of some trait over the course of several generations." [FBC:GD]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003148
@@ -6809,8 +6809,8 @@ name: interspecific hybrid
 namespace: biosample_attribute
 def: "A sample that is derived from a controlled mating between individuals of two specific species." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003149
@@ -6818,8 +6818,8 @@ name: mated
 namespace: biosample_attribute
 def: "A sample in which the individuals have undergone mating." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003150
@@ -6827,8 +6827,8 @@ name: virgin
 namespace: biosample_attribute
 def: "A sample in which the individuals have not undergone mating." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003151
@@ -6836,8 +6836,8 @@ name: constant dark
 namespace: biosample_attribute
 def: "A sample that is maintained in conditions comparable to constant darkness." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003152
@@ -6845,8 +6845,8 @@ name: constant light
 namespace: biosample_attribute
 def: "A sample that is maintained in conditions comparable to constant light." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003153
@@ -6854,8 +6854,8 @@ name: light-dark cycle
 namespace: biosample_attribute
 def: "A sample that is maintained in conditions with a specific cycle that included exposure to both light and darkness." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003154
@@ -6863,8 +6863,8 @@ name: primary cell culture
 namespace: biosample_attribute
 def: "A sample that is derived from a primary cell culture." [FBC:CT]
 is_a: FBcv:0003146 ! growth condition
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003155
@@ -6872,8 +6872,8 @@ name: cell culture property
 namespace: biosample_attribute
 def: "Characteristics pertaining to the cell culture conditions used to generate the biosample." [FBC:GD]
 is_a: FBcv:0003137 ! biosample attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003156
@@ -6881,8 +6881,8 @@ name: transiently transfected cell line
 namespace: biosample_attribute
 def: "A sample that contains a transfected agent which is not incorporated into the genome." [FBC:CT]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003157
@@ -6890,8 +6890,8 @@ name: stably transfected cell line
 namespace: biosample_attribute
 def: "A sample that contains a transfected agent which has been stably incorporated into the genome." [FBC:CT]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003158
@@ -6899,8 +6899,8 @@ name: log phase cells
 namespace: biosample_attribute
 def: "A sample that is derived from a population of cells undergoing a log phase of division." [FBC:CT]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003159
@@ -6908,8 +6908,8 @@ name: stationary phase cells
 namespace: biosample_attribute
 def: "A sample that is derived from a population of cells undergoing a stationary phase of division." [FBC:CT]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003160
@@ -6917,8 +6917,8 @@ name: cell cycle synchronized cells
 namespace: biosample_attribute
 def: "A sample that is derived from a population of cells undergoing cell cycle division in a synchronized manner." [FBC:CT]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003161
@@ -6926,8 +6926,8 @@ name: suspension culture
 namespace: biosample_attribute
 def: "The cells that are grown in liquid culture." [FBC:GD]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003162
@@ -6935,8 +6935,8 @@ name: adherent culture
 namespace: biosample_attribute
 def: "The cells that are grown on plates." [FBC:GD]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003163
@@ -6944,8 +6944,8 @@ name: culture supernatant
 namespace: biosample_attribute
 def: "The conditioned medium containing factors secreted by cultured cells that has been isolated." [FBC:GD]
 is_a: FBcv:0003155 ! cell culture property
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003164
@@ -6953,8 +6953,8 @@ name: biosample method
 namespace: biosample_attribute
 def: "Methods pertaining to the experimental treatment or isolation of a biosample." [FBC:GD]
 is_a: FBcv:0003137 ! biosample attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003165
@@ -6962,8 +6962,8 @@ name: gene perturbation
 namespace: biosample_attribute
 def: "A sample that has undergone a disruption to the activity of one of its genes." [FBC:GD]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003166
@@ -6971,8 +6971,8 @@ name: biotic treatment
 namespace: biosample_attribute
 def: "Treatment of an organism with a biological stimulus, such as an infectious or parasitic agent." [FBC:GD]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003167
@@ -6980,8 +6980,8 @@ name: chemical treatment
 namespace: biosample_attribute
 def: "A sample that has been exposed to one or more forms of chemical agent." [FBC:CT]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003168
@@ -6989,8 +6989,8 @@ name: physical treatment
 namespace: biosample_attribute
 def: "A sample that has been exposed to changes in the physical environment including temperature, pressure and radiation." [FBC:GD]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003169
@@ -6998,8 +6998,8 @@ name: tissue dissection
 namespace: biosample_attribute
 def: "A sample that has been dissected from the tissue of a more complete organism." [FBC:CT]
 is_a: FBcv:0009015 ! biosample preparation method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003170
@@ -7007,8 +7007,8 @@ name: cell isolation
 namespace: biosample_attribute
 def: "A single cell type that has been isolated by affinity purification or fluorescent cell sorting." [FBC:GD]
 is_a: FBcv:0009015 ! biosample preparation method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003171
@@ -7016,8 +7016,8 @@ name: subcellular fractionation
 namespace: biosample_attribute
 def: "A sample that has undergone fractionation in order to isolate specific subcellular components for study." [FBC:CT]
 is_a: FBcv:0009015 ! biosample preparation method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003172
@@ -7025,8 +7025,8 @@ name: cell ablation
 namespace: biosample_attribute
 def: "A sample in which specific cells within a tissue have been ablated by some method, such as targeted expression of a cell toxin, or laser ablation of fluorescently marked cells." [FBC:GD]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003173
@@ -7034,8 +7034,8 @@ name: targeted cell labeling
 namespace: biosample_attribute
 def: "A sample that has been labelled in a targeted, cell-specific manner." [FBC:CT]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003174
@@ -7043,8 +7043,8 @@ name: neuronal activity perturbation
 namespace: biosample_attribute
 def: "Neuronal activity that has been perturbed using genetically controlled agents to activate or depress membrane potential." [FBC:GD]
 is_a: FBcv:0009014 ! biosample treatment method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003175
@@ -7052,8 +7052,8 @@ name: assay attribute
 namespace: assay_attribute
 def: "Some characteristic of an assay pertaining to the methods involved in processing the biological source material or generating the raw output data of the assay." [FBC:GD]
 is_a: FBcv:0003121 ! dataset attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003176
@@ -7061,8 +7061,8 @@ name: assay material
 namespace: assay_attribute
 def: "A type of biomolecule that is isolated from a biosample and characterized by downstream steps in an assay." [FBC:GD]
 is_a: FBcv:0003175 ! assay attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003177
@@ -7070,8 +7070,8 @@ name: genomic DNA isolation
 namespace: assay_attribute
 def: "Material that is derived from isolation of genomic DNA." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003178
@@ -7079,8 +7079,8 @@ name: total RNA isolation
 namespace: assay_attribute
 def: "Material that is derived from isolation of the total RNA." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003179
@@ -7088,8 +7088,8 @@ name: poly(A) RNA isolation
 namespace: assay_attribute
 def: "Material that is derived from the isolation of RNA containing a poly(A) tail." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003180
@@ -7097,8 +7097,8 @@ name: short RNA isolation
 namespace: assay_attribute
 def: "The isolation of small RNA species 17-35 nt in size." [FBC:GD]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003181
@@ -7106,8 +7106,8 @@ name: translated mRNA isolation
 namespace: assay_attribute
 def: "Material that is derived from the isolation of translated messenger RNA." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003182
@@ -7115,8 +7115,8 @@ name: protein isolation
 namespace: assay_attribute
 def: "Material that is derived from the isolation of proteins." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003183
@@ -7124,8 +7124,8 @@ name: chromatin isolation
 namespace: assay_attribute
 def: "Material that is derived from the isolation of chromatin and its subcellular components and/or binding partners." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003184
@@ -7133,8 +7133,8 @@ name: RNA-protein isolation
 namespace: assay_attribute
 def: "Isolation of RNA-protein complexes." [FBC:GD]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003185
@@ -7142,8 +7142,8 @@ name: metabolite isolation
 namespace: assay_attribute
 def: "Material that is derived from the isolation of metabolites." [FBC:CT]
 is_a: FBcv:0003176 ! assay material
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003186
@@ -7151,8 +7151,8 @@ name: assay material depletion
 namespace: assay_attribute
 def: "The biosample that is depleted of specific biomolecule types before further processing." [FBC:GD]
 is_a: FBcv:0003175 ! assay attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003187
@@ -7160,8 +7160,8 @@ name: rRNA depletion
 namespace: assay_attribute
 def: "Material that has undergone the depletion of ribosomal RNA." [FBC:CT]
 is_a: FBcv:0003186 ! assay material depletion
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003188
@@ -7169,8 +7169,8 @@ name: ssRNA depletion
 namespace: assay_attribute
 def: "Material that has undergone the depletion of single-stranded RNA." [FBC:CT]
 is_a: FBcv:0003186 ! assay material depletion
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003189
@@ -7178,8 +7178,8 @@ name: dsRNA depletion
 namespace: assay_attribute
 def: "Material that has undergone the depletion of double-stranded RNA." [FBC:CT]
 is_a: FBcv:0003186 ! assay material depletion
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003190
@@ -7187,8 +7187,8 @@ name: unbound RNA depletion
 namespace: assay_attribute
 def: "Material that has undergone the depletion of unbound RNA." [FBC:CT]
 is_a: FBcv:0003186 ! assay material depletion
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003191
@@ -7196,8 +7196,8 @@ name: assay material selection
 namespace: assay_attribute
 def: "The biosample that is enriched for a specific biomolecule type for further processing." [FBC:GD]
 is_a: FBcv:0003175 ! assay attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003192
@@ -7205,8 +7205,8 @@ name: ChIP
 namespace: assay_attribute
 def: "Material that has been selected using Chromatin Immunoprecipitation, or ChIP." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003193
@@ -7214,8 +7214,8 @@ name: DamID
 namespace: assay_attribute
 def: "Material that has been selected using DNA Adenine Methyltransferase Identification, or DamID." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003194
@@ -7223,8 +7223,8 @@ name: FAIRE
 namespace: assay_attribute
 def: "Material that has been selected using formaldehyde-assisted isolation of Regulatory Elements or FAIRE." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003195
@@ -7232,8 +7232,8 @@ name: CAGE
 namespace: assay_attribute
 def: "Material that has been selected using Cap Analysis Gene Expression, in which the 7-methylguanosine cap at 5' transcript ends is biotinylated and affinity purified." [PMID:16489339]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003196
@@ -7241,8 +7241,8 @@ name: MNase
 namespace: assay_attribute
 def: "Chromatin that has been cleaved using micrococcal nuclease to cleave at linker DNA between nucleosomes." [FBC:GD]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003197
@@ -7250,8 +7250,8 @@ name: DNase
 namespace: assay_attribute
 def: "Material that has been selected from a sample treated by deoxyribonuclease." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003198
@@ -7259,8 +7259,8 @@ name: low salt chromatin extraction
 namespace: assay_attribute
 def: "Material that has been selected using a low salt chromatin extraction, typically 80mM." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003199
@@ -7268,8 +7268,8 @@ name: high salt chromatin extraction
 namespace: assay_attribute
 def: "Material that has been selected using a high salt chromatin extraction, typically 600mM." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003200
@@ -7277,8 +7277,8 @@ name: mononucleosomal DNA isolation
 namespace: assay_attribute
 def: "Mononucleosomal fragments, generated by micrococcal nuclease cleavage at linker DNA between nucleosomes, that have been isolated by gel electrophoresis." [FBC:GD]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003201
@@ -7286,8 +7286,8 @@ name: affinity purification
 namespace: assay_attribute
 def: "Material that has been selected using affinity purification." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003202
@@ -7295,8 +7295,8 @@ name: size fractionation
 namespace: assay_attribute
 def: "Material that has been selected using size fractionation." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003203
@@ -7304,8 +7304,8 @@ name: oligo-dT selection
 namespace: assay_attribute
 def: "Material that has been selected using short sequences of deoxy-thymine nucleotides to affinity purify RNA containing long polyA stretches." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003204
@@ -7313,8 +7313,8 @@ name: oligo-dT priming
 namespace: assay_attribute
 def: "Material that has been selected using short sequences of deoxy-thymine nucleotides to prime first strand cDNA synthesis by reverse transcriptase at long polyA stretches." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003205
@@ -7322,8 +7322,8 @@ name: random priming
 namespace: assay_attribute
 def: "Random oligomers that have been used to prime first strand cDNA synthesis by reverse transcriptase at random positions along transcripts." [FBC:GD]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003206
@@ -7331,8 +7331,8 @@ name: density sedimentation
 namespace: assay_attribute
 def: "Material that has been selected based on density via density sedimentation." [FBC:CT]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003207
@@ -7340,8 +7340,8 @@ name: nuclear run-on
 namespace: assay_attribute
 def: "Nucleotide analogs that are used to map the position and orientation of the RNA polymerase active site." [FBC:GD]
 is_a: FBcv:0003191 ! assay material selection
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003208
@@ -7349,8 +7349,8 @@ name: assay method
 namespace: assay_attribute
 def: "A method used to characterize the biological molecules isolated from a biosample." [FBC:GD]
 is_a: FBcv:0003175 ! assay attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003209
@@ -7358,8 +7358,8 @@ name: Sanger sequencing
 namespace: assay_attribute
 def: "A method that uses Sanger sequencing for this assay." [FBC:CT]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003210
@@ -7367,8 +7367,8 @@ name: single molecule real time sequencing
 namespace: assay_attribute
 def: "A method that uses single molecule sequencing, by highly processive DNA polymerase to generate an extremely long single read on the order of several kilobases, for this assay." [FBC:GD]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003211
@@ -7376,8 +7376,8 @@ name: high-throughput sequencing
 namespace: assay_attribute
 def: "A method that uses high-throughput sequencing for this assay." [FBC:CT]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003212
@@ -7385,8 +7385,8 @@ name: 454 sequencing
 namespace: assay_attribute
 def: "A method that uses 454 sequencing, a form of high-throughput sequencing with 400-500 nt read length, for this assay." [FBC:CT]
 is_a: FBcv:0003211 ! high-throughput sequencing
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003213
@@ -7394,8 +7394,8 @@ name: Illumina sequencing
 namespace: assay_attribute
 def: "A method that uses Illumina sequencing, a form of high-throughput sequencing, for this assay." [FBC:CT]
 is_a: FBcv:0003211 ! high-throughput sequencing
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003214
@@ -7403,8 +7403,8 @@ name: Affymetrix Gene Expression Array 1
 namespace: assay_attribute
 def: "A method that uses an Affymetrix Gene Expression Array, version 1, for this assay." [FBC:CT, FBC:GD]
 is_a: FBcv:0003240 ! expression array
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003215
@@ -7412,8 +7412,8 @@ name: Affymetrix Gene Expression Array 2
 namespace: assay_attribute
 def: "A method that uses an Affymetrix Gene Expression Array, version 2, for this assay." [FBC:CT]
 is_a: FBcv:0003240 ! expression array
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003216
@@ -7421,8 +7421,8 @@ name: genomic tiling array
 namespace: assay_attribute
 def: "A method that uses a genomic tiling array, a subtype of microarray chip in which the genome is represented by oligonucleotides at regularly spaced intervals, for this assay." [FBC:CT]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003217
@@ -7430,8 +7430,8 @@ name: peptide array
 namespace: assay_attribute
 def: "A method that uses a peptide array, a subtype of microarray chip, for this assay." [FBC:CT]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003218
@@ -7439,8 +7439,8 @@ name: mass spectrometry
 namespace: assay_attribute
 def: "A method that uses mass spectrometry, an analytical technique for sorting ions based on mass, for this assay." [FBC:CT]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003219
@@ -7448,8 +7448,8 @@ name: two channel scanning
 namespace: assay_attribute
 def: "A method that uses two samples, one a control and the other an experimental sample, for this assay. The samples are labeled in different colors and hybridized to the same oligonucleotide array. Each sample is scanned using different excitation and emission parameters." [FBC:GD]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003220
@@ -7457,8 +7457,8 @@ name: single-end layout
 namespace: assay_attribute
 def: "A method that uses an RNA-seq assay in which only one end of the library fragment is sequenced." [FBC:GD]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003221
@@ -7466,8 +7466,8 @@ name: paired-end layout
 namespace: assay_attribute
 def: "A method that uses an RNA-seq assay in which both ends of the library fragment are sequenced to provide additional mapping constraints." [FBC:GD]
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003222
@@ -7475,8 +7475,8 @@ name: result attribute
 namespace: result_attribute
 def: "Some characteristic of a result pertaining to the methods involved in analyzing the input data, or the content or format of the output data." [FBC:GD]
 is_a: FBcv:0003121 ! dataset attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003223
@@ -7484,8 +7484,8 @@ name: stranded profile
 namespace: result_attribute
 def: "A genomic mapping profile that distinguishes forward and reverse strand distributions." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003224
@@ -7493,8 +7493,8 @@ name: unstranded profile
 namespace: result_attribute
 def: "A genomic mapping profile that does not distinguish between forward and reverse strand mapping." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003225
@@ -7502,8 +7502,8 @@ name: uniquely mapping read alignment
 namespace: result_attribute
 def: "An alignment of high-throughput sequences that includes only those reads mapping uniquely to the genome." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003226
@@ -7511,8 +7511,8 @@ name: multiply mapping read alignment
 namespace: result_attribute
 def: "An alignment of high-throughput sequences that includes reads mapping to multiple sites in the genome. Coverage values for a given sequence weighted equally across the multiple sites to which it maps." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003227
@@ -7520,8 +7520,8 @@ name: RPKM calculation
 namespace: result_attribute
 def: "A unit of expression (reads per kilobase per million reads) in which high-throughput sequencing reads mapping to a given feature are normalized both to the size of that feature and to the total number of reads in the sample." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003228
@@ -7529,8 +7529,8 @@ name: RPMM calculation
 namespace: result_attribute
 def: "A unit of expression (reads per million miRNA reads) in which high-throughput sequencing reads for a given miRNA are normalized against all reads mapping to all miRNA." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003229
@@ -7538,8 +7538,8 @@ name: RPM calculation
 namespace: result_attribute
 def: "A unit of expression (reads per million reads) in which high-throughput sequencing reads for a given type of feature are normalized against all reads mapping to all features of the same type." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003230
@@ -7547,8 +7547,8 @@ name: clone-based finishing
 namespace: result_attribute
 def: "Sequencing the full extent of selected large clones, typically by sub-cloning large inserts as smaller fragments, to improve the accuracy and completeness of an assembly." [FlyBase:FBrf0155823]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003231
@@ -7556,8 +7556,8 @@ name: restriction fingerprinting
 namespace: result_attribute
 def: "Mapping of restriction enzyme recognition sites to develop a physical map of a genome." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003232
@@ -7565,8 +7565,8 @@ name: sequence tagged site mapping
 namespace: result_attribute
 def: "Mapping of short (200-500 bp) sequence-tagged sites (STS) landmarks to develop a physical map of a genome." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003233
@@ -7574,8 +7574,8 @@ name: tiling path
 namespace: result_attribute
 def: "An ordered list of a minimal set of overlapping clones that provides complete coverage across an assembly." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003234
@@ -7583,8 +7583,8 @@ name: cytogenetic mapping
 namespace: result_attribute
 def: "Sequences that have been mapped to mitotic or polytene chromosomes to guide genome assembly." [FBC:GD]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003235
@@ -7592,8 +7592,8 @@ name: assembly level - chromosome
 namespace: result_attribute
 def: "There is sequence for one or more chromosomes. This could be a completely sequenced chromosome without gaps or a chromosome containing scaffolds or contigs with gaps between them. There may also be unplaced or unlocalized scaffolds." [http://www.ncbi.nlm.nih.gov/assembly/help/]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003236
@@ -7601,8 +7601,8 @@ name: assembly level - scaffold
 namespace: result_attribute
 def: "Some sequence contigs have been connected across gaps to create scaffolds, but no scaffolds have been placed on chromosomes." [http://www.ncbi.nlm.nih.gov/assembly/help/]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003237
@@ -7610,8 +7610,8 @@ name: genome representation - full
 namespace: result_attribute
 def: "The assembly represents the whole genome, though there may still be gaps." [http://www.ncbi.nlm.nih.gov/assembly/help/]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003238
@@ -7619,8 +7619,8 @@ name: genome representation - partial
 namespace: result_attribute
 def: "The assembly represents only part of the organism's genome, because only a single chromosome was targeted, coverage is <1, or total length is less than half the average for other assemblies of the same species." [http://www.ncbi.nlm.nih.gov/assembly/help/]
 is_a: FBcv:0003222 ! result attribute
-created_by: mmc46
-creation_date: 2016-02-24T19:19:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-02-24T19:19:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0003239
@@ -7631,16 +7631,16 @@ subset: camcur
 synonym: "change induced by zinc finger nuclease-mediated cleavage" EXACT []
 synonym: "zinc finger nuclease" RELATED []
 is_a: FBcv:0003007 ! site specific cleavage
-created_by: mmc46
-creation_date: 2016-04-06T10:22:52Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-04-06T10:22:52Z xsd:dateTime
 
 [Term]
 id: FBcv:0003240
 name: expression array
 namespace: assay_attribute
 is_a: FBcv:0003208 ! assay method
-created_by: mmc46
-creation_date: 2016-05-17T15:35:41Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0001-5948-3092
+property_value: http://purl.org/dc/terms/date 2016-05-17T15:35:41Z xsd:dateTime
 
 [Term]
 id: FBcv:0005000
@@ -7649,8 +7649,8 @@ namespace: origin_of_mutation
 def: "Sequence change caused by a site specific recombination catalyzed by the serine recombinase Bxb1 integrase that recognizes a minimal high-efficiency attPX recognition site of 48 base pairs and a minimal high-efficiency attBX recognition site of 38 base pairs. The attPX and attBX sites share an 8bp common core flanked by imperfect inverted repeats (19bp in attPX and 8bp in attBX). A non-palindromic central dinucleotide (5'-GT) determines the directionality of integration." [PMID:14636570]
 synonym: "change induced by Bxb1 integrase recombination" EXACT []
 is_a: FBcv:0000478 ! site specific recombination
-created_by: temj2
-creation_date: 2017-06-12T10:56:07Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-12T10:56:07Z xsd:dateTime
 
 [Term]
 id: FBcv:0005001
@@ -7658,8 +7658,8 @@ name: experimental tool descriptor
 def: "Term that describes the use of an experimental tool." [FBC:GM]
 subset: do_not_annotate
 is_a: FBcv:0000013 ! descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005002
@@ -7668,8 +7668,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and confers a specific property that facilitates detection of that gene product by an experimental method." [FBC:GM]
 synonym: "gene product detection tag" RELATED [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005003
@@ -7678,8 +7678,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the RNA product encoded by a transgenic locus or modified endogenous locus and confers a specific property that facilitates detection of that RNA product by an experimental method." [FBC:GM]
 synonym: "RNA detection tag" RELATED [FBC:TJ]
 is_a: FBcv:0005002 ! gene product detection tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005004
@@ -7688,8 +7688,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the protein product encoded by a transgenic locus or modified endogenous locus and confers a specific property that facilitates detection of that protein product by an experimental method." [FBC:GM]
 synonym: "protein detection tag" RELATED [FBC:TJ]
 is_a: FBcv:0005002 ! gene product detection tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005005
@@ -7699,8 +7699,8 @@ def: "Sequence that forms all or part of the protein product encoded by a transg
 subset: common_tool_use
 xref: MI:0365
 is_a: FBcv:0005004 ! protein detection tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005006
@@ -7710,8 +7710,8 @@ def: "Sequence that forms all or part of the protein product encoded by a transg
 subset: common_tool_use
 xref: MI:0687
 is_a: FBcv:0005004 ! protein detection tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005007
@@ -7719,8 +7719,8 @@ name: green fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 499-519nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005008
@@ -7728,8 +7728,8 @@ name: blue fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 424-467nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005009
@@ -7738,8 +7738,8 @@ namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 474-492nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 xref: MI:0733
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005010
@@ -7748,8 +7748,8 @@ namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 524-538nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 xref: MI:0368
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005011
@@ -7757,8 +7757,8 @@ name: orange fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 559-572nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005012
@@ -7767,8 +7767,8 @@ namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 574-610nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 xref: MI:0732
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005013
@@ -7776,8 +7776,8 @@ name: far-red fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak within the wavelength range of 625-659nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005014
@@ -7785,8 +7785,8 @@ name: infra-red fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Protein having well characterized fluorescence excitation and emission spectra, with an emission peak equal or greater than 670nm." [FBC:GM, http://blog.addgene.org/which-fluorescent-protein-should-i-use]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005015
@@ -7794,8 +7794,8 @@ name: modulatable fluorescent protein
 namespace: experimental_tool_descriptor
 def: "A fluorescent protein whose spectral properties are changeable, resulting from a reversible or irreversible change in fluorophore conformation. Changes in fluorophore conformation may occur either as a function of time (in the case of fluorescent timer proteins), or in response to an external trigger such as irradiation with a specific wavelength of light (in the case of photomodulatable fluorescent proteins)." [FBC:TEMJ]
 is_a: FBcv:0005006 ! fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005016
@@ -7803,8 +7803,8 @@ name: photomodulatable fluorescent protein
 namespace: experimental_tool_descriptor
 def: "A fluorescent protein whose spectral properties can be modulated by exposure to light of a specific wavelength, triggering a conformational change of the fluorophore and subsequent change in fluorescent state." [FBC:TEMJ, PMID:20539741]
 is_a: FBcv:0005015 ! modulatable fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005017
@@ -7812,8 +7812,8 @@ name: photoactivatable fluorescent protein
 namespace: experimental_tool_descriptor
 def: "A protein that can be switched from an essentially non-fluorescent state to a fluorescent state by irradiation with a pulse of light of a specific wavelength. This activation is irreversible." [FBC:GM, http://www.leica-microsystems.com/science-lab/photoactivatable-photoconvertable-and-photoswitchable-fluorescent-proteins/]
 is_a: FBcv:0005016 ! photomodulatable fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005018
@@ -7821,8 +7821,8 @@ name: photoconvertible fluorescent protein
 namespace: experimental_tool_descriptor
 def: "A protein that can be converted from one fluorescent state to another fluorescent state (with a changed emission spectrum peak) by irradiation with a pulse of light of a specific wavelength. This conversion is irreversible." [FBC:GM, http://www.leica-microsystems.com/science-lab/photoactivatable-photoconvertable-and-photoswitchable-fluorescent-proteins/]
 is_a: FBcv:0005016 ! photomodulatable fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005019
@@ -7830,8 +7830,8 @@ name: photoswitchable fluorescent protein
 namespace: experimental_tool_descriptor
 def: "A protein that can be reversibly switched between a non-fluorescent state and a fluorescent state, or between two different fluorescent states. The switch from one state to the other is triggered by irradiation with a pulse of light of a specific wavelength, and the switch back to the original state is triggered with a pulse of light of another specific wavelength." [FBC:GM, FBC:TEMJ, http://www.leica-microsystems.com/science-lab/photoactivatable-photoconvertable-and-photoswitchable-fluorescent-proteins/]
 is_a: FBcv:0005016 ! photomodulatable fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005020
@@ -7839,8 +7839,8 @@ name: fluorescent timer protein
 namespace: experimental_tool_descriptor
 def: "A protein that converts from one fluorescent state to another fluorescent state (with a changed emission spectrum peak) over time." [FBC:GM]
 is_a: FBcv:0005015 ! modulatable fluorescent protein
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005021
@@ -7849,8 +7849,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and that encodes an epitope that can be used to detect the presence of the tagged protein product. An epitope (SO:0001018) is defined as 'A binding site that, in the molecule, interacts selectively and non-covalently with antibodies, B cells or T cells.'" [FBC:GM]
 is_a: FBcv:0005004 ! protein detection tool
 is_a: FBcv:0007029 ! specific binding tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005022
@@ -7858,8 +7858,8 @@ name: gene product localization tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged gene product either to a specific subcellular location within the cell or for secretion to the extracellular space." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005023
@@ -7868,8 +7868,8 @@ namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein either to a specific subcellular location within the cell or for secretion to the extracellular space." [FBC:GM, http://en.wikipedia.org/wiki/Target_peptide]
 xref: SO:0001527
 is_a: FBcv:0005022 ! gene product localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005024
@@ -7877,8 +7877,8 @@ name: nuclear protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the nucleus." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005025
@@ -7886,8 +7886,8 @@ name: mitochondrial protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the mitochondrion." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005026
@@ -7895,8 +7895,8 @@ name: peroxisomal protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the peroxisome." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005027
@@ -7904,8 +7904,8 @@ name: centrosome protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the centrosome." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005028
@@ -7913,8 +7913,8 @@ name: microtubule protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the microtubule." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005029
@@ -7922,8 +7922,8 @@ name: endoplasmic reticulum protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the endoplasmic reticulum." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005030
@@ -7931,8 +7931,8 @@ name: Golgi protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the Golgi apparatus." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005031
@@ -7940,8 +7940,8 @@ name: membrane protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to a cellular membrane. The membrane targeting sequence may be an intrinsic component of the membrane (GO:0031224), having some covalently attached portion, for example part of a peptide sequence or some other covalently attached group such as a GPI anchor, which spans or is embedded in one or both leaflets of the membrane; or may be an extrinsic component of the membrane (GO:0019898), being loosely bound to one of its surfaces, but not integrated into the hydrophobic region." [FBC:GM, GOC:dos, GOC:jl, GOC:mah]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005032
@@ -7949,8 +7949,8 @@ name: plasma membrane protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the plasma membrane." [FBC:GM]
 is_a: FBcv:0005031 ! membrane protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005033
@@ -7958,8 +7958,8 @@ name: vesicle protein localization tag
 namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to a vesicle." [FBC:GM]
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005034
@@ -7968,8 +7968,8 @@ namespace: experimental_tool_descriptor
 def: "A peptide sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which is used to target the tagged protein to the secretory pathway. This results in the protein either being secreted or inserted into a cellular membrane, depending on the presence of other specific sequences in the tagged protein. The signal sequence must be fused to the N-terminal end of the tagged protein." [FBC:GM, http://en.wikipedia.org/wiki/Signal_peptide]
 xref: SO:0000418
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005035
@@ -7979,8 +7979,8 @@ def: "A peptide sequence used to target a tagged protein for export from the nuc
 synonym: "NES" EXACT []
 xref: SO:0001531
 is_a: FBcv:0005023 ! protein localization tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005036
@@ -7989,8 +7989,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and confers a specific, novel property that facilitates purification of the gene product and/or any associated macromolecular complex by an experimental method." [FBC:GM]
 synonym: "isolation tag" EXACT []
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005037
@@ -7998,8 +7998,8 @@ name: gene product activity regulation tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which is used to regulate the activity of the tagged gene product." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005038
@@ -8007,8 +8007,8 @@ name: conditional activity regulation tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the activity of the tagged gene product being regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0005037 ! gene product activity regulation tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005039
@@ -8017,8 +8017,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the activity of the tagged gene product being regulated in response to irradiation with a pulse of light." [FBC:GM]
 synonym: "light-dependent activity regulation tag" EXACT []
 is_a: FBcv:0005038 ! conditional activity regulation tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005040
@@ -8027,8 +8027,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 synonym: "small molecule-dependent activity regulation tag" EXACT []
 is_a: FBcv:0005038 ! conditional activity regulation tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005041
@@ -8037,8 +8037,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the protein encoded by a transgenic locus or modified endogenous locus and which allows a protein to be inactivated by the chromophore-assisted light inactivation (CALI) technique. The tag consists of a peptide sequence that specifically binds a membrane-permeable, chromophore-containing molecule. When activated using a pulse of high-intensity light that is absorbed by the chromophore but not by cellular components, the membrane-permeable molecule generates short-lived reactive oxygen species which inactivate the tagged protein to which the molecule is bound via the chromophore-assisted light inactivation tag." [FBC:GM, PMID:14625562, PMID:16605242, PMID:21226520, PMID:3399501]
 synonym: "CALI tag" EXACT []
 is_a: FBcv:0005039 ! light-regulated activity regulation tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005042
@@ -8046,8 +8046,8 @@ name: gene product degradation tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being targeted for degradation, where this property can be regulated by a specific process or entity." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005043
@@ -8055,8 +8055,8 @@ name: cell cycle-regulated gene product degradation tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being targeted for degradation, where this property can be regulated by the cell cycle." [FBC:GM]
 is_a: FBcv:0005042 ! gene product degradation tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005044
@@ -8064,8 +8064,8 @@ name: genetically encoded sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of a biologically relevant property that is not part of or directly encoded by the genome, for example pH, redox state, membrane potential, a change in concentration of a particular molecule. For experimental tools that are used to detect a gene product directly encoded by the genome, see instead 'gene product detection tag'." [FBC:GM, PMID:20664080]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005045
@@ -8073,8 +8073,8 @@ name: small molecule sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the protein product encoded by a transgenic locus or modified endogenous locus and confers a specific property that facilitates detection of a molecule that is not part of or directly encoded by the genome." [FBC:GM]
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005046
@@ -8082,8 +8082,8 @@ name: calcium ion sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of calcium ion concentration." [FBC:GM]
 is_a: FBcv:0005045 ! small molecule sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005047
@@ -8091,8 +8091,8 @@ name: pH sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of pH." [FBC:GM]
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005048
@@ -8100,8 +8100,8 @@ name: voltage sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of voltage." [FBC:GM]
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005049
@@ -8109,8 +8109,8 @@ name: redox state sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of the redox state of a cell/tissue." [FBC:GM]
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005050
@@ -8118,8 +8118,8 @@ name: mechanical force sensor
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of changes in the mechanical force the gene product is subjected to." [FBC:GM]
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005051
@@ -8127,8 +8127,8 @@ name: split system component
 namespace: experimental_tool_descriptor
 def: "Component that forms part of a 'split system'. A split system component corresponds to a non-functional fragment of a functional experimental tool that would normally be encoded by a single gene product. When combined with another appropriate split system component in vivo, a functional experimental tool is produced. The fragments of a split system can be brought together in vivo in a number of different ways; for example, by fusing fragments to peptides that physically interact in vivo." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005052
@@ -8136,8 +8136,8 @@ name: split fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Non-fluorescent fragment of a fluorescent protein. A functional fluorophore can be reconstituted if a split fluorescent protein fragment is expressed with a complementary split fluorescent protein fragment and the fragments are brought together in vivo, permitting the study of biological interactions. Protein-protein interactions can be studied using the bimolecular fluorescence complementation (BiFC) technique, where a fluorescent protein is reconstituted if the two complementary split fluorescent protein fragments are fused to interacting proteins or protein domains that bring the split halves together into the same macromolecular complex. Associations between closely apposed cells can be studied if the two complementary split fluorescent protein fragments are tethered to the surface of these cells, for example to study connectivity in the nervous system using the GFP Reconstitution Across Synaptic Partners (GRASP) technique." [FBC:GM, PMID:11983170, PMID:18255029]
 is_a: FBcv:0005051 ! split system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005053
@@ -8145,8 +8145,8 @@ name: split reporter enzyme
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the protein product encoded by a transgenic locus or modified endogenous locus and that encodes a catalytically inactive fragment of an enzyme whose activity can be used to detect the presence of that protein product when complementary split reporter enzyme fragments are brought together in vivo. Fragments may be brought together when fused to peptides that physically interact, permitting the study of protein-protein interactions." [FBC:GM, http://orcid.org/0000-0002-1373-1705, PMID:9237989]
 is_a: FBcv:0005051 ! split system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005054
@@ -8154,8 +8154,8 @@ name: split driver - DNA-binding fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain. A functional transcription driver can be reconstituted if this split system component is brought together in vivo with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain." [FBC:GM, FlyBase:FBrf0193617]
 is_a: FBcv:0005051 ! split system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005055
@@ -8164,8 +8164,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain. A functional transcription driver can be reconstituted if this split system component is brought together in vivo with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain." [FBC:GM, FlyBase:FBrf0193617]
 subset: common_tool_use
 is_a: FBcv:0005051 ! split system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005056
@@ -8173,8 +8173,8 @@ name: gene product cleavage tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which allows the tagged gene product to be cleaved (broken into smaller molecules by the rupture of a covalent bond) by a specific process." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005057
@@ -8182,8 +8182,8 @@ name: protein cleavage tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which allows the tagged protein product to be cleaved (broken into smaller molecules by the rupture of a covalent bond) by a specific process. Examples of protein cleavage tags include sequences recognized and cleaved by proteases such as the human rhinovirus (HRV) 3C protease (often produced with the tradename PreScission Protease) and the tobacco etch virus (TEV) protease. Protein product cleavage can be used for a number of different purposes, including release of a protein after purification, or removal of a detection tag to assess that the tag does not interfere with protein function." [FBC:GM, FBC:TEMJ]
 is_a: FBcv:0005056 ! gene product cleavage tag
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005058
@@ -8191,8 +8191,8 @@ name: binary expression system component
 namespace: experimental_tool_descriptor
 def: "Component that forms part of a binary expression system. This system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. In addition, a specific repressor protein may be available which prevents the transactivator from driving expression, allowing further refinement of the expression pattern of the responder." [FBC:GM, FlyBase:FBrf0216478]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005059
@@ -8201,8 +8201,8 @@ namespace: experimental_tool_descriptor
 def: "Transactivator ('driver') that is encoded by a transgenic locus or modified endogenous locus and which forms part of a binary expression system. This system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. In addition, a specific repressor protein may be available which prevents the transactivator from driving expression, allowing further refinement of the expression pattern of the responder." [FBC:GM, FlyBase:FBrf0216478]
 subset: common_tool_use
 is_a: FBcv:0005058 ! binary expression system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005060
@@ -8212,8 +8212,8 @@ def: "Specific DNA sequence that is used as the effector in a binary expression 
 synonym: "binary expression system - effector" EXACT []
 is_a: FBcv:0005058 ! binary expression system component
 is_a: FBcv:0005082 ! engineered transcription regulatory region
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005061
@@ -8222,8 +8222,8 @@ namespace: experimental_tool_descriptor
 def: "Repressor that can be used to regulate expression in a binary expression system. This system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. In addition, a specific repressor protein may be available which prevents the transactivator from driving expression, allowing further refinement of the expression pattern of the responder." [FBC:GM, FlyBase:FBrf0216478]
 subset: common_tool_use
 is_a: FBcv:0005058 ! binary expression system component
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005062
@@ -8233,8 +8233,8 @@ def: "An enzyme that mediates a recombination exchange reaction between two DNA 
 subset: common_tool_use
 synonym: "site-specific recombinase" EXACT []
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005063
@@ -8243,8 +8243,8 @@ namespace: experimental_tool_descriptor
 def: "The recognition site for a particular site-specific recombinase, an enzyme that mediates a recombination exchange reaction between two DNA templates, each containing a copy of the recognition site. The recognition site contains perfect inverted repeats flanking an asymmetric spacer. Under normal conditions, the two recognition sites are identical and are reformed during the recombination event, and thus the reaction is bidirectional: recombination can occur in both 'forward' and 'reverse' directions. However, recognition sites can be mutated to drive the directionality of the reaction: different classes of site may be combined so that recombination can occur in one direction, but produces reformed sites that are no longer compatible. In addition, mutually exclusive sites have been engineered for some recombinases. Recombinases can be used to generate many different types of genetic modification, with the outcome being influenced by the relative orientation (direct or inverted), relative location and composition of the two recognition sites. The types of possible modification include deletion of DNA, generation of chromosomal rearrangements, integration of DNA into the genome, and replacement of genetic material with that from a donor plasmid using recombination-mediated cassette exchange (RMCE)." [FlyBase:FBrf0231034]
 synonym: "site-specific recombination target region" EXACT []
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-06-28T11:41:27Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-06-28T11:41:27Z xsd:dateTime
 
 [Term]
 id: FBcv:0005064
@@ -8252,8 +8252,8 @@ name: binary expression system - conditional driver
 namespace: experimental_tool_descriptor
 def: "Transactivator ('driver') that forms part of a binary expression system and whose activity is regulated in response to a particular stimulus. A binary expression system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. Use of a conditional driver permits further refinement of this expression pattern." [FBC:GM]
 is_a: FBcv:0005059 ! binary expression system - driver
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005065
@@ -8261,8 +8261,8 @@ name: binary expression system - small molecule-regulated driver
 namespace: experimental_tool_descriptor
 def: "Transactivator ('driver') that forms part of a binary expression system and whose activity is regulated by binding to a small molecule, such as an ion or ligand. A binary expression system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. Use of a small molecule-regulated driver driver permits further refinement of this expression pattern." [FBC:GM]
 is_a: FBcv:0005064 ! binary expression system - conditional driver
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005066
@@ -8270,8 +8270,8 @@ name: binary expression system - conditional repressor
 namespace: experimental_tool_descriptor
 def: "Repressor that can be used to regulate expression in a binary expression system and whose activity is regulated in response to a particular stimulus. A binary expression system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. In addition, a specific repressor protein may be available which prevents the transactivator from driving expression, allowing further refinement of the expression pattern of the responder. Use of a conditional repressor permits further refinement of this expression pattern." [FBC:GM]
 is_a: FBcv:0005061 ! binary expression system - repressor
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005067
@@ -8279,8 +8279,8 @@ name: binary expression system - temperature conditional repressor
 namespace: experimental_tool_descriptor
 def: "Repressor that can be used to regulate expression in a binary expression system and whose activity is regulated by temperature. A binary expression system requires a transactivator ('driver') that binds to a specific DNA sequence ('regulatory region' or 'effector'). A driver encoded by one transgenic locus or modified endogenous locus is used to drive expression of a downstream 'responder' or 'reporter' encoded by another transgenic locus or modified endogenous locus, by fusing the regulatory region sequence to which the driver binds upstream of the responder sequence. The temporal and spatial expression pattern of the responder thus depends on the regulatory elements used to drive expression of the driver. In addition, a specific repressor protein may be available which prevents the transactivator from driving expression, allowing further refinement of the expression pattern of the responder. Use of a temperature conditional repressor permits further refinement of this expression pattern." [FBC:GM]
 is_a: FBcv:0005066 ! binary expression system - conditional repressor
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005068
@@ -8288,8 +8288,8 @@ name: insertional mutagenesis tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of a transgenic locus or modified endogenous locus and which is designed to impact or assess any proximate gene(s) when integrated into the genome." [FBC:GM, FBC:LC]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005069
@@ -8299,8 +8299,8 @@ def: "An enhancer trap cassette is designed to report or utilize the expression 
 synonym: "enhancer detection tool" RELATED [FBC:GM]
 xref: SO:0001479
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005070
@@ -8308,8 +8308,8 @@ name: protein trap
 namespace: experimental_tool_descriptor
 def: "A protein trap cassette is designed to tag protein(s) encoded by an endogenous locus upon integration of the cassette into the genome. The basic structure of a protein trap cassette is an artificial exon composed of a splice acceptor site, an open reading frame without initiation and stop codons, and a splice donor site. No promoter sequences are present. Upon integration into a coding intron of an endogenous locus, the open reading frame (ORF) encoded by the artificial exon can be incorporated into ('tag') the protein encoded by the locus. This only occurs if the insertion is in the correct orientation and when the frame of the artificial exon corresponds to that of the preceeding exon. Thus, only one out of six insertions in a coding intron will function as a protein trap. To account for each reading frame, three versions of a given protein trap element, differing only in the splice phase, are typically produced for use in an insertional mutagenesis screen. Depending on the nature of the ORF encoded by the artificial exon, the tag may be used to detect the expression pattern and/or subcellular localization of the protein (e.g. if the tag is an epitope tag or fluorescent protein), to drive expression of a gene of interest (e.g. if the tag is a driver that forms part of a binary expression system), or may modify the properties of the endogenous protein (e.g. if the tag affects protein localization or stability). A protein trap cassette may be inserted into a genome as part of a transgenic construct via transposable-element-mediated transgenesis, or may be inserted directly into a modified endogenous locus via a genome engineering method such as homologous recombination or CRISPR. The presence of the splice acceptor and donor sites mean that a protein trap cassette is not inherently mutagenic, since it is designed to insert in frame into a protein. However, an insertion into an intron that splits a critical functional or localization domain may alter the activity of the encoded protein, and the protein trap tag sequence itself may be designed to alter function (for example targeting the protein to a new location within the cell or altering its stability)." [FBC:GM, FlyBase:FBrf0216478, FlyBase:FBrf0236840]
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005071
@@ -8318,8 +8318,8 @@ namespace: experimental_tool_descriptor
 def: "A gene trap cassette is designed to interrupt transcription of an endogenous locus upon integration of the cassette into the genome. The basic components of a gene trap cassette are a promoterless gene with an upstream splice acceptor site. Upon integration into an intron, splicing from the genomic splice donor site to the splice acceptor site in the cassette results in a transcriptional fusion containing the endogenous exon(s) upstream of the insertion fused to the gene sequence encoded by the cassette. Any open reading frame (ORF) encoded by the trap cassette gene may be translated from this transcriptional fusion either as a translational fusion with any ORF sequence encoded by the upstream exons, or if an internal ribosome entry site (IRES) or viral 2A-like peptide sequence (which promotes ribosome skipping) is present upstream of the gene trap ORF, it may be produced as a separate protein expressed under the control of the regulatory sequences of the endogenous locus. Gene trap insertions are usually mutagenic, disrupting the locus into which they have inserted, since termination sequences are usually present at the 3' end of the cassette, truncating the endogenous transcript. Depending on the nature of the gene encoded by the gene trap cassette, a gene trap insertion may directly report the expression pattern of the disrupted locus (e.g. if it encodes a reporter enzyme or fluorescent protein), or it may be used to drive expression of any gene of interest in the pattern of the trapped locus (e.g. if it is a driver that forms part of a binary expression system). A gene trap cassette may be inserted into a genome as part of a transgenic construct via transposable-element-mediated transgenesis, or may be inserted directly into a modified endogenous locus via a genome engineering method such as homologous recombination or CRISPR." [FBC:GM, http://www.genetrap.org/tutorials/overview.html#vector, PMID:10899970]
 xref: SO:0001477
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005072
@@ -8327,8 +8327,8 @@ name: polyA trap
 namespace: experimental_tool_descriptor
 def: "The basic components of a polyA trap cassette are a promoter fused to a gene sequence that lacks a polyadenylation (polyA) sequence but is followed by a splice donor sequence. If the cassette is integrated into the genome outside a gene, the mRNA produced by the polyA trap is not polyadenylated and is expected to be rapidly degraded. However, if the cassette is integrated into an intron, the promoter in the polyA trap will drive expression of a transcriptional fusion containing the polyA gene trap fused to any downstream exons. The downstream terminal exon can provide a polyA signal, allowing stable expression of the gene encoded by the polyA trap. polyA trap cassettes can be used to report the expression of genes that are not normally expressed, or are expressed at very low levels, or may be used as a marker of successful integration of an insertion into a transcription unit. A polyA trap cassette may be inserted into a genome as part of a transgenic construct via transposable-element-mediated transgenesis, or may be inserted directly into a modified endogenous locus via a genome engineering method such as homologous recombination or CRISPR." [FBC:GM, FlyBase:FBrf0132344, FlyBase:FBrf0206814, http://www.genetrap.org/tutorials/overview.html#vector, PMID:9560157]
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005073
@@ -8336,8 +8336,8 @@ name: promoter trap
 namespace: experimental_tool_descriptor
 def: "The basic component of a promoter trap cassette is a promoterless gene. This gene is not flanked by splice acceptor or donor sites, and thus the gene within a promoter trap can only be expressed if the cassette integrates into the genome within an exon, resulting in a transcriptional fusion. If the promoter trap gene encodes an open reading frame (ORF) and the insertion is in the correct frame, the trap ORF may be translated from this transcriptional fusion either as a translational fusion with ORF sequence of the disrupted endogenous locus, or if an internal ribosome entry site (IRES) or viral 2A-like peptide sequence (which promotes ribosome skipping) is present upstream of the promoter trap ORF, it may be produced as a separate protein expressed under the control of the regulatory sequences of the endogenous locus. Depending on the nature of the gene encoded by the promoter trap cassette, the insertion may directly report the expression pattern of the 'trapped' locus (e.g. if the gene encoded by the cassette is a reporter enzyme or fluorescent protein), or it may be used to drive expression of any gene of interest (e.g. if the gene encoded by the cassette is a driver that form part of a binary expression system). A promoter trap cassette may be inserted into a genome as part of a transgenic construct via transposable-element-mediated transgenesis, or may be inserted directly into a modified endogenous locus via a genome engineering method such as homologous recombination or CRISPR. Promoter trap insertions are usually mutagenic, disrupting the locus into which they have inserted, since termination sequences are usually present at the 3' end of the cassette, truncating the endogenous transcript." [FBC:GM, PMID:10899970]
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005074
@@ -8345,8 +8345,8 @@ name: misexpression element
 namespace: experimental_tool_descriptor
 def: "The basic components of a misexpression element are an enhancer sequence plus a minimal promoter. Upon integration into the genome, this element can activate expression of nearby endogenous loci. Typically, constructs containing misexpression elements are designed to insert at or near the 5' end of a gene, such that expression from the promoter within the misexpression element drives overexpression of the endogenous locus and causes a gain-of-function phenotype. However, if the insertion is within a locus, a truncated product may be produced, while an insertion in the opposite orientation to that of the direction of transcription of the endogenous locus can result in the production of an antisense transcript. If the enhancer present in the misexpression element forms part of a binary expression system, the misexpression pattern of the endogenous gene is controlled by combining the misexpression element insertion with a driver expressed in the desired temporal and spatial pattern." [FBC:GM, FlyBase:FBrf0090768]
 is_a: FBcv:0005068 ! insertional mutagenesis tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005075
@@ -8354,8 +8354,8 @@ name: genome engineering tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of a transgenic locus or modified endogenous locus and which can be used to an modify an organism's genetic material in a defined manner. Genome engineering can occur on many levels, ranging from targeting of an individual gene with a small modification through to the engineering of chromosomal rearrangements. In addition to the manipulation of endogenous loci, genome engineering can also be used to introduce exogenous material into the genome, and to manipulate such exogenous material already introduced the genome." [FlyBase:FBrf0231034]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005076
@@ -8364,8 +8364,8 @@ namespace: experimental_tool_descriptor
 def: "An enzyme that mediates an exchange reaction between two DNA templates, resulting in integration of DNA from one of the templates into the other. An integrase binds a pair of compatible recognition sites (typically called attP and attB) which each contain a short integration core flanked by imperfect inverted repeats that are not identical. Exchange between the attP/attB pair results in the formation of hybrid sites (typically called attL and attR) that are no longer a substrate of the integrase. Thus the exchange reaction driven by an integrase is unidirectional. Mutually exclusive pairs of recognition site have been engineered for some integrases. Integrases can be used to generate many different types of genetic modification, with the outcome being influenced by the relative orientation (direct or inverted), relative location and composition of the two recognition sites. The types of possible modification include deletion of DNA, generation of chromosomal rearrangements, integration of DNA into the genome, and replacement of genetic material with that from a donor plasmid using recombination-mediated cassette exchange (RMCE)." [FlyBase:FBrf0231034]
 subset: common_tool_use
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005077
@@ -8375,8 +8375,8 @@ def: "An enzyme that catalyzes hydrolysis of DNA in a site-specific manner. When
 subset: common_tool_use
 synonym: "site-specific DNA nuclease" RELATED [FBC:GM]
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005078
@@ -8385,8 +8385,8 @@ namespace: experimental_tool_descriptor
 def: "An enzyme that catalyzes hydrolysis of DNA in a site-specific manner, and in which the specificity is determined by a guide RNA that contains sequence complementary to the DNA sequence of interest, rather than being an inherent property of the nuclease itself." [FBC:GM, FlyBase:FBrf0231034]
 subset: common_tool_use
 is_a: FBcv:0005077 ! nuclease
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005079
@@ -8394,8 +8394,8 @@ name: integrase target site
 namespace: experimental_tool_descriptor
 def: "A recognition site for an integrase, an enzyme that mediates an exchange reaction between two DNA templates, resulting in integration of DNA from one of the templates into the other. An integrase binds a pair of compatible recognition sites (typically called attP and attB) which each contain a short integration core flanked by imperfect inverted repeats that are not identical. Exchange between the attP/attB pair results in the formation of hybrid sites (typically called attL and attR) that are no longer a substrate of the integrase. Thus the exchange reaction driven by an integrase is unidirectional. Mutually exclusive pairs of recognition site have been engineered for some integrases. Integrases can be used to generate many different types of genetic modification, with the outcome being influenced by the relative orientation (direct or inverted), relative location and composition of the two recognition sites. The types of possible modification include deletion of DNA, generation of chromosomal rearrangements, integration of DNA into the genome, and replacement of genetic material with that from a donor plasmid using recombination-mediated cassette exchange (RMCE)." [FlyBase:FBrf0231034]
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005080
@@ -8403,8 +8403,8 @@ name: nuclease target site
 namespace: experimental_tool_descriptor
 def: "A recognition site for a site-specific DNA nuclease, an enzyme that catalyzes hydrolysis of DNA in a site-specific manner. The DNA cutting stimulates cellular repair mechanisms, which can be exploited to produce genome modifications. For example, repair by homologous recombination in the presence of an exogenous template can be used to introduce targeted changes into the genome." [FBC:GM, FlyBase:FBrf0231034]
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005081
@@ -8412,8 +8412,8 @@ name: engineered regulatory region
 namespace: experimental_tool_descriptor
 def: "Engineered sequence that forms all or part of a transgenic locus or modified endogenous locus and that has the property of a 'regulatory_region' (SO:0005836). 'regulatory_region' is defined as 'A region of sequence that is involved in the control of a biological process." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005082
@@ -8421,8 +8421,8 @@ name: engineered transcription regulatory region
 namespace: experimental_tool_descriptor
 def: "Engineered sequence that forms all or part of a transgenic locus or modified endogenous locus and that has the property of a 'transcription_regulatory_region' (SO:0001679). 'transcription_regulatory_region' is defined as 'A regulatory region that is involved in the control of the process of transcription.'." [FBC:GM]
 is_a: FBcv:0005081 ! engineered regulatory region
-created_by: temj2
-creation_date: 2017-12-13T13:17:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-13T13:17:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0005083
@@ -8431,8 +8431,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being targeted for degradation, where this property can be regulated by a small molecule." [FBC:GM]
 synonym: "small molecule-dependent gene product degradation tag" EXACT []
 is_a: FBcv:0005042 ! gene product degradation tag
-created_by: temj2
-creation_date: 2017-12-22T13:09:10Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
+property_value: http://purl.org/dc/terms/date 2017-12-22T13:09:10Z xsd:dateTime
 
 [Term]
 id: FBcv:0007000
@@ -8442,8 +8442,8 @@ def: "A short report describing a single stand-alone research finding that is pe
 comment: Obsoleted, as 'paper' publication type will now be used for micropublications.
 is_obsolete: true
 replaced_by: FBcv:0000212
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T08:45:04Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T08:45:04Z xsd:dateTime
 
 [Term]
 id: FBcv:0007001
@@ -8451,8 +8451,8 @@ name: preprint
 namespace: pub_type
 def: "A version of a scientific manuscript that is shared publicly on the web without peer review. In most cases, work posted as a preprint will be submitted for peer review at a journal." [FBC:SM, http://www.asapbio.org/preprint-info]
 is_a: FBcv:0000189 ! publication class
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T09:00:50Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T09:00:50Z xsd:dateTime
 
 [Term]
 id: FBcv:0007002
@@ -8462,8 +8462,8 @@ def: "Sequence that forms all or part of the gene product encoded by a transgeni
 subset: common_tool_use
 synonym: "electrically signalling cell activity regulation tool" EXACT []
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T09:54:56Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T09:54:56Z xsd:dateTime
 
 [Term]
 id: FBcv:0007003
@@ -8472,8 +8472,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to inhibit the activity of a neuron. This is often achieved by inducing membrane hyperpolarization (GO:0060081)." [FBC:GM]
 synonym: "electrically signalling cell inhibition tool" EXACT []
 is_a: FBcv:0007002 ! neuron activity regulation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:13:24Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:13:24Z xsd:dateTime
 
 [Term]
 id: FBcv:0007004
@@ -8481,8 +8481,8 @@ name: conditional neuron inhibition tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to inhibit the activity of a neuron, where this property can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0007003 ! neuron inhibition tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:15:49Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:15:49Z xsd:dateTime
 
 [Term]
 id: FBcv:0007005
@@ -8491,8 +8491,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to inhibit the activity of a neuron, where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
 synonym: "optogenetic neuron inhibition tool" EXACT []
 is_a: FBcv:0007004 ! conditional neuron inhibition tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:17:16Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:17:16Z xsd:dateTime
 
 [Term]
 id: FBcv:0007006
@@ -8500,8 +8500,8 @@ name: small molecule-regulated neuron inhibition tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to inhibit the activity of a neuron, where this property can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0007004 ! conditional neuron inhibition tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:18:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:18:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0007007
@@ -8510,8 +8510,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to inhibit the activity of a neuron, where this property can be regulated by temperature." [FBC:GM]
 synonym: "thermogenetic neuron inhibition tool" EXACT []
 is_a: FBcv:0007004 ! conditional neuron inhibition tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:20:00Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:20:00Z xsd:dateTime
 
 [Term]
 id: FBcv:0007008
@@ -8520,8 +8520,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to stimulate the activity of a neuron. This is often achieved by inducing membrane depolarization (GO:0051899)." [FBC:GM]
 synonym: "electrically signalling cell activation tool" EXACT []
 is_a: FBcv:0007002 ! neuron activity regulation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:25:57Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:25:57Z xsd:dateTime
 
 [Term]
 id: FBcv:0007009
@@ -8529,8 +8529,8 @@ name: conditional neuron activation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to stimulate the activity of a neuron, where this property can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0007008 ! neuron activation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:26:57Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:26:57Z xsd:dateTime
 
 [Term]
 id: FBcv:0007010
@@ -8539,8 +8539,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to stimulate the activity of a neuron, where this property can be regulated by temperature." [FBC:GM]
 synonym: "thermogenetic neuron activation tool" EXACT []
 is_a: FBcv:0007009 ! conditional neuron activation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:28:57Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:28:57Z xsd:dateTime
 
 [Term]
 id: FBcv:0007011
@@ -8549,8 +8549,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to stimulate the activity of a neuron, where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
 synonym: "optogenetic neuron activation tool" EXACT []
 is_a: FBcv:0007009 ! conditional neuron activation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:31:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:31:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0007012
@@ -8558,8 +8558,8 @@ name: small molecule-regulated neuron activation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to stimulate the activity of a neuron, where this property can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0007009 ! conditional neuron activation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:34:48Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:34:48Z xsd:dateTime
 
 [Term]
 id: FBcv:0007013
@@ -8568,8 +8568,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure." [FBC:GM]
 subset: common_tool_use
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:53:21Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:53:21Z xsd:dateTime
 
 [Term]
 id: FBcv:0007014
@@ -8577,8 +8577,8 @@ name: conditional cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure, where this property can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0007013 ! cell ablation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:54:32Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:54:32Z xsd:dateTime
 
 [Term]
 id: FBcv:0007015
@@ -8586,8 +8586,8 @@ name: temperature-regulated cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure, where this property can be regulated by temperature." [FBC:GM]
 is_a: FBcv:0007014 ! conditional cell ablation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:55:40Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:55:40Z xsd:dateTime
 
 [Term]
 id: FBcv:0007016
@@ -8595,8 +8595,8 @@ name: light-regulated cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure, where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
 is_a: FBcv:0007014 ! conditional cell ablation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:56:47Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:56:47Z xsd:dateTime
 
 [Term]
 id: FBcv:0007017
@@ -8604,8 +8604,8 @@ name: small molecule-regulated cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure, where this property can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0007014 ! conditional cell ablation tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T10:57:45Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T10:57:45Z xsd:dateTime
 
 [Term]
 id: FBcv:0007018
@@ -8614,8 +8614,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of the activity of a specific biological process." [FBC:GM]
 synonym: "reporter of biological process pathway activity" EXACT []
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T11:38:48Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T11:38:48Z xsd:dateTime
 
 [Term]
 id: FBcv:0007019
@@ -8624,8 +8624,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of the activity of a specific signal transduction pathway." [FBC:GM]
 synonym: "reporter of signal transduction pathway activity" EXACT []
 is_a: FBcv:0007018 ! biological process activity sensor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T11:41:19Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T11:41:19Z xsd:dateTime
 
 [Term]
 id: FBcv:0007020
@@ -8634,8 +8634,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that is used to provide a readout of the activation state of a specific gene product." [FBC:GM]
 synonym: "gene product activation state detection tool" EXACT []
 is_a: FBcv:0005044 ! genetically encoded sensor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T11:43:24Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T11:43:24Z xsd:dateTime
 
 [Term]
 id: FBcv:0007021
@@ -8644,8 +8644,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that encodes an enzyme which covalently tags neighboring macromolecules, facilitating the subsequent purification or detection of the tagged macromolecules by an experimental method." [FBC:GM, PMID:30774936]
 subset: common_tool_use
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:01:14Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:01:14Z xsd:dateTime
 
 [Term]
 id: FBcv:0007022
@@ -8653,8 +8653,8 @@ name: proximity labeling tool (protein)
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that encodes an enzyme which covalently tags neighboring proteins, facilitating the subsequent purification or detection of the tagged proteins by an experimental method." [FBC:GM, PMID:29125959, PMID:30774936]
 is_a: FBcv:0007021 ! proximity labeling tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:08:26Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:08:26Z xsd:dateTime
 
 [Term]
 id: FBcv:0007023
@@ -8662,8 +8662,8 @@ name: proximity labeling tool (RNA)
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that encodes an enzyme which covalently tags neighboring RNA, facilitating the subsequent purification or detection of the tagged RNA by an experimental method." [FBC:GM, PMID:30774936]
 is_a: FBcv:0007021 ! proximity labeling tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:18:36Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:18:36Z xsd:dateTime
 
 [Term]
 id: FBcv:0007024
@@ -8671,8 +8671,8 @@ name: proximity labeling tool (DNA)
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that encodes an enzyme which covalently tags neighboring DNA, facilitating the subsequent purification or detection of the tagged DNA by an experimental method." [FBC:GM, PMID:30774936]
 is_a: FBcv:0007021 ! proximity labeling tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:24:50Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:24:50Z xsd:dateTime
 
 [Term]
 id: FBcv:0007025
@@ -8680,8 +8680,8 @@ name: cell labeling tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property that can be used to facilitate the detection of a specific cell population by an experimental method." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:41:38Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:41:38Z xsd:dateTime
 
 [Term]
 id: FBcv:0007026
@@ -8689,8 +8689,8 @@ name: multicolor cell labeling tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and confers a specific property that can be used to stochastically label cells in the same sample with different colors of fluorescent protein. This property can be exploited to study cell morphology and to track lineages of clonally related cells." [FBC:GM, PMID:25491327]
 is_a: FBcv:0007025 ! cell labeling tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:42:41Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:42:41Z xsd:dateTime
 
 [Term]
 id: FBcv:0007027
@@ -8698,8 +8698,8 @@ name: small molecule-regulated protein cleavage tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which allows the tagged protein product to be cleaved (broken into smaller molecules by the rupture of a covalent bond) by a specific process that can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0005057 ! protein cleavage tag
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-25T14:58:18Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-25T14:58:18Z xsd:dateTime
 
 [Term]
 id: FBcv:0007028
@@ -8707,8 +8707,8 @@ name: split recombinase
 namespace: experimental_tool_descriptor
 def: "Catalytically inactive fragment of a recombinase. A functional recombinase can be reconstituted when complementary split recombinase fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
 is_a: FBcv:0005051 ! split system component
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T07:55:34Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T07:55:34Z xsd:dateTime
 
 [Term]
 id: FBcv:0007029
@@ -8717,8 +8717,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that has a property that allows specific binding to another macromolecule." [FBC:GM]
 subset: common_tool_use
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T08:11:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T08:11:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0007030
@@ -8726,8 +8726,8 @@ name: conditional specific binding tool
 namespace: experimental_tool_descriptor
 def: "Sequence that has a property that allows specific binding to another macromolecule, where this property can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0007029 ! specific binding tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T08:12:05Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T08:12:05Z xsd:dateTime
 
 [Term]
 id: FBcv:0007031
@@ -8735,8 +8735,8 @@ name: light-regulated specific binding tool
 namespace: experimental_tool_descriptor
 def: "Sequence that has a property that allows specific binding to another macromolecule, where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
 is_a: FBcv:0007030 ! conditional specific binding tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T08:13:06Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T08:13:06Z xsd:dateTime
 
 [Term]
 id: FBcv:0007032
@@ -8744,8 +8744,8 @@ name: temperature-regulated specific binding tool
 namespace: experimental_tool_descriptor
 def: "Sequence that has a property that allows specific binding to another macromolecule, where this property can be regulated by temperature." [FBC:GM]
 is_a: FBcv:0007030 ! conditional specific binding tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T08:13:56Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T08:13:56Z xsd:dateTime
 
 [Term]
 id: FBcv:0007033
@@ -8753,8 +8753,8 @@ name: small molecule-regulated specific binding tool
 namespace: experimental_tool_descriptor
 def: "Sequence that has a property that allows specific binding to another macromolecule, where this property can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0007030 ! conditional specific binding tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T08:14:35Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T08:14:35Z xsd:dateTime
 
 [Term]
 id: FBcv:0007035
@@ -8762,8 +8762,8 @@ name: meganuclease
 namespace: experimental_tool_descriptor
 def: "An enzyme that catalyzes hydrolysis of DNA in a site-specific manner, having a cognate recognition site of 20-30bp. When used in vivo, the DNA cutting stimulates cellular repair mechanisms, which can be exploited to produce genome modifications. For example, repair by homologous recombination in the presence of an exogenous template can be used to introduce targeted changes into the genome." [FBC:GM, FlyBase:FBrf0231034]
 is_a: FBcv:0005077 ! nuclease
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2019-06-26T09:17:20Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2019-06-26T09:17:20Z xsd:dateTime
 
 [Term]
 id: FBcv:0007036
@@ -8771,8 +8771,8 @@ name: lecture
 namespace: pub_type
 def: "Work consisting of speeches read or delivered before an audience or class, especially for instruction or to set forth some subject." [MeSH:D019531]
 is_a: FBcv:0000189 ! publication class
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-01-23T15:24:54Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-01-23T15:24:54Z xsd:dateTime
 
 [Term]
 id: FBcv:0007037
@@ -8782,8 +8782,8 @@ def: "An immunoglobulin molecule having a specific amino acid sequence that give
 subset: common_tool_use
 xref: XCO:0000194
 is_a: FBcv:0007029 ! specific binding tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-01-24T08:44:55Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-01-24T08:44:55Z xsd:dateTime
 
 [Term]
 id: FBcv:0007038
@@ -8791,8 +8791,8 @@ name: light conditional
 namespace: environmental_qualifier
 def: "Phenotype expressed only in the presence or absence of light, which may be white light or particular wavelength(s)." [FBC:CP]
 is_a: FBcv:0000309 ! conditional
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-01-24T09:10:41Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-01-24T09:10:41Z xsd:dateTime
 
 [Term]
 id: FBcv:0007039
@@ -8800,8 +8800,8 @@ name: engineered antibody
 namespace: experimental_tool_descriptor
 def: "An antibody whose domain architecture has been engineered in vitro. An engineered antibody typically contains only a subset of the domains found in a naturally occurring antibody. In some cases, domains that are normally found in different chains of a naturally occurring antibody are synthesized as a single fusion protein." [FBC:GM]
 is_a: FBcv:0007037 ! antibody
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T11:36:12Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T11:36:12Z xsd:dateTime
 
 [Term]
 id: FBcv:0007040
@@ -8809,8 +8809,8 @@ name: nanobody
 namespace: experimental_tool_descriptor
 def: "An engineered antibody consisting of the antigen-binding variable domain (VHH domain) of a camelid single-domain heavy chain antibody (HCab)." [FBC:GM, PMID:22886243, PMID:8502296, PMID:9323027]
 is_a: FBcv:0007039 ! engineered antibody
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T11:51:11Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T11:51:11Z xsd:dateTime
 
 [Term]
 id: FBcv:0007041
@@ -8821,8 +8821,8 @@ synonym: "scFv antibody" EXACT [FBC:GM]
 synonym: "sFv antibody" EXACT [PMID:3045807]
 synonym: "single-chain variable region fragment antibody" EXACT [PMID:3045807]
 is_a: FBcv:0007039 ! engineered antibody
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T12:25:24Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T12:25:24Z xsd:dateTime
 
 [Term]
 id: FBcv:0007042
@@ -8831,8 +8831,8 @@ namespace: experimental_tool_descriptor
 def: "An RMCE target element contains a region of DNA sequence flanked by a pair of target sites for a recombinase or an integrase, which are arranged such that this target sequence cassette can be replaced with donor sequence from a compatible RMCE donor element via recombination-mediated cassette exchange (RMCE). For RMCE mediated by a recombinase, the target cassette is flanked by two non-identical recombinase target sites that each carry a different mutation in the spacer sequence of the target site; this renders the two sites incompatible with each other. A compatible RMCE donor cassette is flanked by the same pair of non-identical sites; in the presence of recombinase, a double recombination event between the identical sites on the donor and target sequences results in replacement of the target cassette with the donor cassette. In the case of RMCE mediated by an integrase, the RMCE cassette is flanked by identical integrase target sites, while a compatible RMCE donor cassette is flanked by copies of the orthogonal integrase target site; in the presence of integrase, a double recombination event results in the target cassette being replaced with that of the donor cassette. In this case, if the flanking sites are in inverted orientation, replacement of the target cassette can occur in either direction." [FBC:GM, FlyBase:FBrf0231034, PMID:21445009, PMID:7947678]
 synonym: "recombination-mediated cassette exchange target element" EXACT []
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T14:52:50Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T14:52:50Z xsd:dateTime
 
 [Term]
 id: FBcv:0007043
@@ -8841,8 +8841,8 @@ namespace: experimental_tool_descriptor
 def: "An RMCE donor element contains a region of DNA sequence flanked by a pair of target sites for a recombinase or an integrase, which are arranged such that this donor sequence cassette can be used to replace target sequence of a compatible RMCE target element via recombination-mediated cassette exchange (RMCE). For RMCE mediated by a recombinase, the target cassette is flanked by two non-identical recombinase target sites that each carry a different mutation in the spacer sequence of the target site; this renders the two sites incompatible with each other. A compatible RMCE donor cassette is flanked by the same pair of non-identical sites; in the presence of recombinase, a double recombination event between the identical sites on the donor and target sequences results in replacement of the target cassette with the donor cassette. In the case of RMCE mediated by an integrase, the RMCE cassette is flanked by identical integrase target sites, while a compatible RMCE donor cassette is flanked by copies of the orthogonal integrase target site; in the presence of integrase, a double recombination event results in the target cassette being replaced with that of the donor cassette. In this case, if the flanking sites are in inverted orientation, replacement of the target cassette can occur in either direction." [FBC:GM, FlyBase:FBrf0231034, PMID:21445009, PMID:7947678]
 synonym: "recombination-mediated cassette exchange donor element" EXACT []
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T15:00:41Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T15:00:41Z xsd:dateTime
 
 [Term]
 id: FBcv:0007044
@@ -8853,8 +8853,8 @@ comment: This includes any element containing a single site for integrase-mediat
 synonym: "docking site element" EXACT []
 synonym: "landing site element" EXACT []
 is_a: FBcv:0005075 ! genome engineering tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-03T15:54:09Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-03T15:54:09Z xsd:dateTime
 
 [Term]
 id: FBcv:0007045
@@ -8863,8 +8863,8 @@ namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of a transgenic locus or modified endogenous locus and which can be used to modify an RNA of interest in a defined manner. Examples of RNA engineering include the targeting of an individual transcript for knockdown, and targeted manipulation of RNA splicing or editing." [FBC:GM, PMID:30021724, PMID:30388409, PMID:31367845]
 subset: common_tool_use
 is_a: FBcv:0005001 ! experimental tool descriptor
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-04T09:01:14Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-04T09:01:14Z xsd:dateTime
 
 [Term]
 id: FBcv:0007046
@@ -8873,8 +8873,8 @@ namespace: experimental_tool_descriptor
 def: "An enzyme that catalyzes hydrolysis of RNA in a site-specific manner, and in which the specificity is determined by a guide RNA that contains sequence complementary to the target RNA sequence of interest, rather than being an inherent property of the ribonuclease itself. This property can be used to modify an organism's transcriptome in a defined manner." [FBC:GM, PMID:30021724, PMID:30388409, PMID:31367845]
 subset: common_tool_use
 is_a: FBcv:0007045 ! RNA engineering tool
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-02-04T09:12:14Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-02-04T09:12:14Z xsd:dateTime
 
 [Term]
 id: FBcv:0007047
@@ -8882,8 +8882,8 @@ name: light-regulated gene product degradation tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being targeted for degradation, where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
 is_a: FBcv:0005042 ! gene product degradation tag
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-12-10T13:05:28Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-12-10T13:05:28Z xsd:dateTime
 
 [Term]
 id: FBcv:0007048
@@ -8891,8 +8891,8 @@ name: decreased number
 namespace: structural_qualifier
 def: "Present in the correct location but in smaller numbers than in wild-type." [FBC:CP]
 is_a: FBcv:0000014 ! structural qualifier
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-12-14T14:38:52Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-12-14T14:38:52Z xsd:dateTime
 
 [Term]
 id: FBcv:0007049
@@ -8901,8 +8901,8 @@ namespace: structural_qualifier
 def: "Anatomical structure that would be present in wild-type is not present." [FBC:CP]
 xref: PATO:0000462
 is_a: FBcv:0000014 ! structural qualifier
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2020-12-14T14:39:35Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2020-12-14T14:39:35Z xsd:dateTime
 
 [Term]
 id: FBcv:0007050
@@ -8910,8 +8910,8 @@ name: somatic clone - tissue specific
 namespace: clone_qualifier
 def: "A clone of somatic cells that share a genotype that is different from the genotype of the animal and are intentionally generated in a specific tissue of the organism." [FBC:AO]
 is_a: FBcv:0000336 ! somatic clone
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2021-08-26T09:58:12Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2021-08-26T09:58:12Z xsd:dateTime
 
 [Term]
 id: FBcv:0007051
@@ -8920,8 +8920,8 @@ namespace: clone_qualifier
 def: "A clone of somatic cells that share a mutant genotype that includes being Minute +/+ and that are part of and derived from an animal with a different genotype that includes being Minute +/- and are intentionally generated in a specific tissue of the organism." [FBC:CP]
 intersection_of: FBcv:0000722 ! somatic clone - Minute background
 intersection_of: FBcv:0007050 ! somatic clone - tissue specific
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2021-08-26T10:04:31Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2021-08-26T10:04:31Z xsd:dateTime
 
 [Term]
 id: FBcv:0007052
@@ -8929,8 +8929,8 @@ name: light-regulated nuclear export signal
 namespace: experimental_tool_descriptor
 def: "A peptide sequence used to target a tagged protein for export from the nucleus to the cytoplasm, where this property can be regulated by irradiation with a pulse of light." [FBC:GM, FlyBase:FBrf0253050, PMID:26853913]
 is_a: FBcv:0005035 ! nuclear export signal
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-04-26T11:49:16Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-04-26T11:49:16Z xsd:dateTime
 
 [Term]
 id: FBcv:0007053
@@ -8938,8 +8938,8 @@ name: conditional split driver - transcription activation fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
 is_a: FBcv:0005055 ! split driver - transcription activation fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:32:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:32:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0007054
@@ -8947,8 +8947,8 @@ name: light-regulated split driver - transcription activation fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
 is_a: FBcv:0007053 ! conditional split driver - transcription activation fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:33:41Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:33:41Z xsd:dateTime
 
 [Term]
 id: FBcv:0007055
@@ -8956,8 +8956,8 @@ name: small molecule-regulated split driver - transcription activation fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
 is_a: FBcv:0007053 ! conditional split driver - transcription activation fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:34:38Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:34:38Z xsd:dateTime
 
 [Term]
 id: FBcv:0007056
@@ -8965,8 +8965,8 @@ name: conditional split driver - DNA-binding fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
 is_a: FBcv:0005054 ! split driver - DNA-binding fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:35:30Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:35:30Z xsd:dateTime
 
 [Term]
 id: FBcv:0007057
@@ -8974,8 +8974,8 @@ name: light-regulated split driver - DNA-binding fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
 is_a: FBcv:0007056 ! conditional split driver - DNA-binding fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:37:56Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:37:56Z xsd:dateTime
 
 [Term]
 id: FBcv:0007058
@@ -8983,8 +8983,8 @@ name: small molecule-regulated split driver - DNA-binding fragment
 namespace: experimental_tool_descriptor
 def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
 is_a: FBcv:0007056 ! conditional split driver - DNA-binding fragment
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:38:38Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:38:38Z xsd:dateTime
 
 [Term]
 id: FBcv:0007059
@@ -8992,8 +8992,8 @@ name: conditional recombinase
 namespace: experimental_tool_descriptor
 def: "An enzyme that mediates a recombination exchange reaction between two DNA templates, each containing a specific recognition site (defined by the enzyme itself), where the activity of the enzyme can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0005062 ! recombinase
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:52:00Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:52:00Z xsd:dateTime
 
 [Term]
 id: FBcv:0007060
@@ -9001,8 +9001,8 @@ name: small molecule-regulated recombinase
 namespace: experimental_tool_descriptor
 def: "An enzyme that mediates a recombination exchange reaction between two DNA templates, each containing a specific recognition site (defined by the enzyme itself), where the activity of the enzyme can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
 is_a: FBcv:0007059 ! conditional recombinase
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:53:20Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:53:20Z xsd:dateTime
 
 [Term]
 id: FBcv:0007061
@@ -9010,8 +9010,8 @@ name: conditional split recombinase
 namespace: experimental_tool_descriptor
 def: "Catalytically inactive fragment of a recombinase that can be used to reconstitute a functional recombinase when brought together in vivo with a complementary split recombinase fragment, where the process that brings the complementary fragments together can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0007028 ! split recombinase
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:56:23Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:56:23Z xsd:dateTime
 
 [Term]
 id: FBcv:0007062
@@ -9019,8 +9019,8 @@ name: light-regulated split recombinase
 namespace: experimental_tool_descriptor
 def: "Catalytically inactive fragment of a recombinase that can be used to reconstitute a functional recombinase when brought together in vivo with a complementary split recombinase fragment, where the process that brings the complementary fragments together can be regulated by irradiation with a pulse of light." [FBC:GM]
 is_a: FBcv:0007061 ! conditional split recombinase
-created_by: http://orcid.org/0000-0002-1373-1705
-creation_date: 2022-05-04T14:57:37Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date 2022-05-04T14:57:37Z xsd:dateTime
 
 [Term]
 id: FBcv:0009000
@@ -9031,8 +9031,8 @@ synonym: "scRNA-Seq" EXACT [PMID:32405060]
 synonym: "single-cell RNA sequencing assay" EXACT []
 xref: OBI:0002631
 is_a: FBcv:0003068 ! RNA-Seq
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T12:18:07Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T12:18:07Z xsd:dateTime
 
 [Term]
 id: FBcv:0009001
@@ -9042,8 +9042,8 @@ def: "A method for quantifying the transcriptome of individual cells, in which t
 synonym: "single-nucleus RNA sequencing assay" EXACT []
 synonym: "snRNA-Seq" EXACT [PMID:32405060]
 is_a: FBcv:0009000 ! single-cell RNA-Seq
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T12:19:45Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T12:19:45Z xsd:dateTime
 
 [Term]
 id: FBcv:0009002
@@ -9051,8 +9051,8 @@ name: cell clustering analysis
 namespace: result_type
 def: "A result that groups individual cells into populations sharing a similar transcriptional profile." [PMID:28821273]
 is_a: FBcv:0003108 ! analysis
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T12:21:05Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T12:21:05Z xsd:dateTime
 
 [Term]
 id: FBcv:0009003
@@ -9060,8 +9060,8 @@ name: transcriptional cell cluster
 namespace: result_type
 def: "A result that represents a population of cells sharing a similar transcriptional profile." [PMID:28821273]
 is_a: FBcv:0003082 ! result type
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T12:22:16Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T12:22:16Z xsd:dateTime
 
 [Term]
 id: FBcv:0009004
@@ -9069,8 +9069,8 @@ name: isolated nuclei
 namespace: biosample_type
 def: "A biosample containing dissociated cell nuclei isolated from the organism." [FBC:DPG]
 is_a: FBcv:0003044 ! biosample type
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T12:23:17Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T12:23:17Z xsd:dateTime
 
 [Term]
 id: FBcv:0009005
@@ -9078,8 +9078,8 @@ name: single-cell library sequencing
 namespace: assay_attribute
 def: "A method to prepare and sequence a library of cDNAs obtained from single cells." [FBC:DPG]
 is_a: FBcv:0003208 ! assay method
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T13:40:26Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T13:40:26Z xsd:dateTime
 
 [Term]
 id: FBcv:0009006
@@ -9087,8 +9087,8 @@ name: DROP-Seq
 namespace: assay_attribute
 def: "A method that uses the DROP-Seq platform (Macosko et al., 2015) to prepare and sequence a cDNA library." [PMID:26000488]
 is_a: FBcv:0009005 ! single-cell library sequencing
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T13:41:58Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T13:41:58Z xsd:dateTime
 
 [Term]
 id: FBcv:0009007
@@ -9096,8 +9096,8 @@ name: Smart-seq2
 namespace: assay_attribute
 def: "A method that uses the Smart-seq2 platform (Picelli et al., 2013) to prepare and sequence a cDNA library." [PMID:24056875]
 is_a: FBcv:0009005 ! single-cell library sequencing
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T13:44:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T13:44:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0009008
@@ -9105,8 +9105,8 @@ name: 10x sequencing
 namespace: assay_attribute
 def: "A method that uses the Chromium platform from 10x Genomics to prepare and sequence a cDNA library." [PMID:29126257]
 is_a: FBcv:0009005 ! single-cell library sequencing
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2021-07-26T13:45:06Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2021-07-26T13:45:06Z xsd:dateTime
 
 [Term]
 id: FBcv:0009009
@@ -9114,8 +9114,8 @@ name: starvation
 namespace: biosample_attribute
 def: "A sample in which individuals have been deprived of food." [FBC:DPG]
 is_a: FBcv:0003146 ! growth condition
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-03T18:11:36Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-03T18:11:36Z xsd:dateTime
 
 [Term]
 id: FBcv:0009010
@@ -9124,8 +9124,8 @@ namespace: biosample_attribute
 def: "A sample in which a biological specimen has been separated into individual cells." [EFO:0009091]
 xref: EFO:0009091
 is_a: FBcv:0009015 ! biosample preparation method
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-16T14:12:02Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-16T14:12:02Z xsd:dateTime
 
 [Term]
 id: FBcv:0009011
@@ -9134,8 +9134,8 @@ namespace: biosample_attribute
 def: "A sample in which a biological specimen has been separated into individual cells by applying mechanical forces." [EFO:0009129]
 xref: EFO:0009129
 is_a: FBcv:0009010 ! cell dissociation
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-16T14:14:12Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-16T14:14:12Z xsd:dateTime
 
 [Term]
 id: FBcv:0009012
@@ -9144,8 +9144,8 @@ namespace: biosample_attribute
 def: "A sample in which a biological specimen has been separated into individual cells by using enzymes." [EFO:0009128]
 xref: EFO:0009128
 is_a: FBcv:0009010 ! cell dissociation
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-16T14:16:03Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-16T14:16:03Z xsd:dateTime
 
 [Term]
 id: FBcv:0009013
@@ -9154,8 +9154,8 @@ namespace: biosample_attribute
 def: "A sample in which a biological specimen has been separated into individual cells by using non-enzymatic chemicals." [EFO:0011026]
 xref: EFO:0011026
 is_a: FBcv:0009010 ! cell dissociation
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-16T14:19:01Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-16T14:19:01Z xsd:dateTime
 
 [Term]
 id: FBcv:0009014
@@ -9163,8 +9163,8 @@ name: biosample treatment method
 namespace: biosample_attribute
 def: "Experimental treatment method that a biosample has been subjected to." [FBC:DPG]
 is_a: FBcv:0003164 ! biosample method
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-17T13:55:39Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-17T13:55:39Z xsd:dateTime
 
 [Term]
 id: FBcv:0009015
@@ -9172,8 +9172,8 @@ name: biosample preparation method
 namespace: biosample_attribute
 def: "Method pertaining to the collection or isolation of a biosample." [FBC:DPG]
 is_a: FBcv:0003164 ! biosample method
-created_by: http://orcid.org/0000-0002-6095-8718
-creation_date: 2022-02-17T14:12:00Z
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date 2022-02-17T14:12:00Z xsd:dateTime
 
 [Term]
 id: FBcv:0010000


### PR DESCRIPTION
Replace `oboInOwl:created_by` and `oboInOwl:creation_date` annotations by `dcterms:contributor` and `dcterms:date`, respectively. This is part of a global move applying to all OBO ontologies.