### PR TITLE
Allow `property_value` tags in OBO files.

### DIFF
--- a/external_tools/perl_modules/releases/OboModel.pm
+++ b/external_tools/perl_modules/releases/OboModel.pm
@@ -72,7 +72,7 @@ sub obo_array {
     my @v=split(/\n/,$_);
     foreach(@v) {
 # Warn of unknown tags with STDERR
-     print STDERR "Unrecognized tag \"$_\"\n", unless ($_ =~ m/^name\: |^id\: |^namespace\: |^def\: |^comment\: |^intersection_of\: |^relationship\: |^xref\: |^synonym\: |^is_a\: |^subset\: |^union_of\: |^is_obsolete\: |^is_anonymous\: |^disjoint_from\: |^alt_id\: |^consider\: |^replaced_by\: |^creation_date\: |^created_by\: |^exact_synonym\: |^broad_synonym\: |^narrow_synonym\: |^related_synonym\: |^xref_analog\: |^equivalent_to\: /);
+     print STDERR "Unrecognized tag \"$_\"\n", unless ($_ =~ m/^name\: |^id\: |^namespace\: |^def\: |^comment\: |^intersection_of\: |^relationship\: |^xref\: |^synonym\: |^is_a\: |^subset\: |^union_of\: |^is_obsolete\: |^is_anonymous\: |^disjoint_from\: |^alt_id\: |^consider\: |^replaced_by\: |^creation_date\: |^created_by\: |^exact_synonym\: |^broad_synonym\: |^narrow_synonym\: |^related_synonym\: |^xref_analog\: |^equivalent_to\: |^property_value\: /);
      print STDERR "Badly formated relationship: $_\n", if (($_ =~ m/(intersection|is_a)\: \w+\:\d+/) && (!($_ =~ m/(intersection|is_a)\: \w+\:\d+( \!|$)/)));
      print STDERR "Badly formated relationship: $_\n", if (($_ =~ m/(intersection|relationship)\:  \S+ \w+\:\d+/) && (!($_ =~ m/(intersection|is_a)\: \S+ \w+\:\d+( \!|$)/)));
      push @ir, { estat => 'rel', rel => $1, obj => $2, an =>'', axref => '' }, if ($_ =~ m/relationship\: (\S+) (\w+\:\d+)/);

--- a/external_tools/perl_modules/trunk/OboModel.pm
+++ b/external_tools/perl_modules/trunk/OboModel.pm
@@ -72,7 +72,7 @@ sub obo_array {
     my @v=split(/\n/,$_);
     foreach(@v) {
 # Warn of unknown tags with STDERR
-     print STDERR "Unrecognized tag \"$_\"\n", unless ($_ =~ m/^name\: |^id\: |^namespace\: |^def\: |^comment\: |^intersection_of\: |^relationship\: |^xref\: |^synonym\: |^is_a\: |^subset\: |^union_of\: |^is_obsolete\: |^is_anonymous\: |^disjoint_from\: |^alt_id\: |^consider\: |^replaced_by\: |^creation_date\: |^created_by\: |^exact_synonym\: |^broad_synonym\: |^narrow_synonym\: |^related_synonym\: |^xref_analog\: |^equivalent_to\: /);
+     print STDERR "Unrecognized tag \"$_\"\n", unless ($_ =~ m/^name\: |^id\: |^namespace\: |^def\: |^comment\: |^intersection_of\: |^relationship\: |^xref\: |^synonym\: |^is_a\: |^subset\: |^union_of\: |^is_obsolete\: |^is_anonymous\: |^disjoint_from\: |^alt_id\: |^consider\: |^replaced_by\: |^creation_date\: |^created_by\: |^exact_synonym\: |^broad_synonym\: |^narrow_synonym\: |^related_synonym\: |^xref_analog\: |^equivalent_to\: |^property_value\: /);
      print STDERR "Badly formated relationship: $_\n", if (($_ =~ m/(intersection|is_a)\: \w+\:\d+/) && (!($_ =~ m/(intersection|is_a)\: \w+\:\d+( \!|$)/)));
      print STDERR "Badly formated relationship: $_\n", if (($_ =~ m/(intersection|relationship)\:  \S+ \w+\:\d+/) && (!($_ =~ m/(intersection|is_a)\: \S+ \w+\:\d+( \!|$)/)));
      push @ir, { estat => 'rel', rel => $1, obj => $2, an =>'', axref => '' }, if ($_ =~ m/relationship\: (\S+) (\w+\:\d+)/);


### PR DESCRIPTION
Fix the OboModel.pm module to prevent it from emitting a warning upon reading a `property_value` tag. This tag is defined in the OBO Flatfile format specification and should therefore be considered valid.

Treating this tag as "unrecognized" is especially problematic now that we have switched metadata annotations from `oboInOwl:` to `dcterms:`, because `dcterms:` annotations are unknown in the OBO Flatfile format and therefore represented as generic `property_value` tags, instead of specific tags such as `created_by` or `creation_date`.