### PR TITLE
Remove the data-version header in the -edit file.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -1,5 +1,4 @@
 format-version: 1.2
-data-version: 2018-01-03
 subsetdef: abnormal_slim "Abnormal/normal slim"
 subsetdef: absent_slim "Absent/present slim"
 subsetdef: attribute_slim "Attribute slim"


### PR DESCRIPTION
The `data-version` header in the -edit file is stuck to '2018-01-03'. Not really useful, if not downright confusing. All the released OBO files always have an automatically generated, correct `data-version` header anyway.

closes #62