### PR TITLE
Update the experimental tool tree

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9036,6 +9036,26 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-03-24T18:05:17Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009023
+name: protease
+namespace: experimental_tool_descriptor
+def: "An enzyme that catalyzes hydrolysis of a peptide bond." [GO:0008233]
+subset: common_tool_use
+synonym: "peptidase" EXACT [FBC:GM]
+is_a: FBcv:0009022 ! gene product engineering tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-03-24T18:18:03Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009024
+name: protease target site
+namespace: experimental_tool_descriptor
+def: "A recognition site for a protease, an enzyme that catalyzes hydrolysis of a peptide bond." [FBC:GM]
+is_a: FBcv:0005057 ! protein cleavage tag
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-03-24T18:24:12Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9027,6 +9027,15 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-02-24T19:33:34Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009022
+name: gene product engineering tool
+namespace: experimental_tool_descriptor
+def: "Sequence that forms all or part of a transgenic locus or modified endogenous locus and which can be used to modify a gene product of interest in a defined manner." [FBC:GM]
+is_a: FBcv:0005001 ! experimental tool descriptor
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-03-24T18:05:17Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -7950,7 +7950,7 @@ id: FBcv:0005056
 name: gene product cleavage tag
 namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which allows the tagged gene product to be cleaved (broken into smaller molecules by the rupture of a covalent bond) by a specific process." [FBC:GM]
-is_a: FBcv:0005001 ! experimental tool descriptor
+is_a: FBcv:0009022 ! gene product engineering tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
 
@@ -8640,7 +8640,7 @@ name: RNA engineering tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of a transgenic locus or modified endogenous locus and which can be used to modify an RNA of interest in a defined manner. Examples of RNA engineering include the targeting of an individual transcript for knockdown, and targeted manipulation of RNA splicing or editing." [FBC:GM, PMID:30021724, PMID:30388409, PMID:31367845]
 subset: common_tool_use
-is_a: FBcv:0005001 ! experimental tool descriptor
+is_a: FBcv:0009022 ! gene product engineering tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
 property_value: http://purl.org/dc/terms/date "2020-02-04T09:01:14Z" xsd:dateTime
 


### PR DESCRIPTION
This PR:

* adds a new _gene product engineering tool_ to encompass tools that allow to modify a gene product in a defined manner, and re-classify existing such tools accordingly;
* adds a subclass of _protein cleavage tag_ to refer to cleavage tags that are recognised and acted upon by a protease (to distinguish from cleavage tags that do no involve the action of a protease);
* adds a term to represent proteases, as a _gene product engineering tool_.

Closes #200 