### PR TITLE
Add 'driver-specific gene expression profile'.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9056,6 +9056,15 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-03-24T18:24:12Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009025
+name: driver-specific gene expression profile
+namespace: result_type
+def: "A result that provides the expression values for all (or some subset of) genes in a given biological sample obtained using a specific transcriptional driver (or combination of drivers), when that driver is not associated to a clearly identified cell type." [FBC:DPG]
+is_a: FBcv:0003088 ! gene expression profile
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-04-21T12:58:46Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.


### PR DESCRIPTION
This PR adds a new type of dataset result for transcriptional profiles associated with a specific transcriptional driver, when that driver is not known to be associated with a precisely identified cell type.

This is primarily intended for TAPINseq-type datasets, where some drivers may label unknown cell types (or possibly a mix of cell types). Even without a cell type, downstream projects (especially VFB) might still want the associated expression data.