### PR TITLE
Add missing namespace on FBcv:0009016.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -8976,6 +8976,7 @@ property_value: http://purl.org/dc/terms/date "2022-02-17T14:12:00Z" xsd:dateTim
 [Term]
 id: FBcv:0009016
 name: conditional gene product degradation tag
+namespace: experimental_tool_descriptor
 def: "Sequence that forms part of the gene product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product being targeted for degradation, where this property can be regulated in response to a particular stimulus." [FBC:GM]
 is_a: FBcv:0005042 ! gene product degradation tag
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718


### PR DESCRIPTION
The term for 'conditional gene product degradation tag' (FBcv:0009016) is in the default "FlyBase miscellaneous CV" namespace, while it should be in the "experimental_tool_descriptor" namespace.