### PR TITLE
Add 'split system combination'.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9066,6 +9066,15 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-04-21T12:58:46Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009026
+name: split system combination
+namespace: experimental_tool_descriptor
+def: "A combination of two or more 'split system components' that together reconstitute a functional experimental tool." [FBC:GM]
+is_a: FBcv:0005001 ! experimental tool descriptor
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-07-24T11:13:29Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.


### PR DESCRIPTION
This PR adds a new term in the experimental tool descriptor branch to represent combinations of split system components. This will notably be used to represent combination of hemidrivers.

closes #207 