### PR TITLE
Update split driver terms

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9075,6 +9075,42 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-07-24T11:13:29Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009027
+name: split driver fragment
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a transcriptional activator ('driver') that can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment, for example by including a compatible physical interaction domain or split intein fragment in each of the complementary split driver fragments." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-07-31T17:10:54Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009028
+name: conditional split driver fragment
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a transcriptional activator ('driver') that can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment, where the process that brings the complementary fragments together can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0009027 ! split driver fragment
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-07-31T17:13:57Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009029
+name: light-regulated split driver fragment
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a transcriptional activator ('driver') that can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment, where the process that brings the complementary fragments together can be regulated by irradiation with a pulse of light." [FBC:GM]
+is_a: FBcv:0009028 ! conditional split driver fragment
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-07-31T17:16:35Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009030
+name: small-molecule regulated split driver fragment
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a transcriptional activator ('driver') that can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment, where the process that brings the complementary fragments together can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
+is_a: FBcv:0009028 ! conditional split driver fragment
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2023-07-31T17:18:43Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -7930,8 +7930,8 @@ property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTim
 id: FBcv:0005054
 name: split driver - DNA-binding fragment
 namespace: experimental_tool_descriptor
-def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain. A functional transcription driver can be reconstituted if this split system component is brought together in vivo with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain." [FBC:GM, FlyBase:FBrf0193617]
-is_a: FBcv:0005051 ! split system component
+def: "Non-functional fragment of a transcriptional activator ('driver') that includes a DNA-binding domain and which can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment that encodes a transcription activation domain, for example by including a compatible physical interaction domain or split intein fragment in each of the complementary split driver fragments." [FBC:GM]
+is_a: FBcv:0009027 ! split driver fragment
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
 
@@ -7939,9 +7939,9 @@ property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTim
 id: FBcv:0005055
 name: split driver - transcription activation fragment
 namespace: experimental_tool_descriptor
-def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain. A functional transcription driver can be reconstituted if this split system component is brought together in vivo with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain." [FBC:GM, FlyBase:FBrf0193617]
+def: "Non-functional fragment of a transcriptional activator ('driver') that includes a transcription activation domain and which can be used to reconstitute a functional transcription driver when brought together in vivo with a complementary split driver fragment that encodes a DNA-binding domain, for example by including a compatible physical interaction domain or split intein fragment in each of the complementary split driver fragments." [FBC:GM]
 subset: common_tool_use
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009027 ! split driver fragment
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
 

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -8712,57 +8712,45 @@ property_value: http://purl.org/dc/terms/date "2022-04-26T11:49:16Z" xsd:dateTim
 
 [Term]
 id: FBcv:0007053
-name: conditional split driver - transcription activation fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
-is_a: FBcv:0005055 ! split driver - transcription activation fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:32:02Z" xsd:dateTime
+name: obsolete conditional split driver - transcription activation fragment
+is_obsolete: true
+consider: FBcv:0005055
+consider: FBcv:0009028
 
 [Term]
 id: FBcv:0007054
-name: light-regulated split driver - transcription activation fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
-is_a: FBcv:0007053 ! conditional split driver - transcription activation fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:33:41Z" xsd:dateTime
+name: obsolete light-regulated split driver - transcription activation fragment
+is_obsolete: true
+consider: FBcv:0005055
+consider: FBcv:0009029
 
 [Term]
 id: FBcv:0007055
-name: small molecule-regulated split driver - transcription activation fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
-is_a: FBcv:0007053 ! conditional split driver - transcription activation fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:34:38Z" xsd:dateTime
+name: obsolete small molecule-regulated split driver - transcription activation fragment
+is_obsolete: true
+consider: FBcv:0005055
+consider: FBcv:0009030
 
 [Term]
 id: FBcv:0007056
-name: conditional split driver - DNA-binding fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
-is_a: FBcv:0005054 ! split driver - DNA-binding fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:35:30Z" xsd:dateTime
+name: obsolete conditional split driver - DNA-binding fragment
+is_obsolete: true
+consider: FBcv:0005054
+consider: FBcv:0009028
 
 [Term]
 id: FBcv:0007057
-name: light-regulated split driver - DNA-binding fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
-is_a: FBcv:0007056 ! conditional split driver - DNA-binding fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:37:56Z" xsd:dateTime
+name: obsolete light-regulated split driver - DNA-binding fragment
+is_obsolete: true
+consider: FBcv:0005054
+consider: FBcv:0009029
 
 [Term]
 id: FBcv:0007058
-name: small molecule-regulated split driver - DNA-binding fragment
-namespace: experimental_tool_descriptor
-def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
-is_a: FBcv:0007056 ! conditional split driver - DNA-binding fragment
-property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
-property_value: http://purl.org/dc/terms/date "2022-05-04T14:38:38Z" xsd:dateTime
+name: obsolete small molecule-regulated split driver - DNA-binding fragment
+is_obsolete: true
+consider: FBcv:0009030
+created_by: FBcv:0005054
 
 [Term]
 id: FBcv:0007059


### PR DESCRIPTION
This PR implements the changes requested in #209.

Basically, it redefines what a split driver fragment is by separating the type of domains that make up the split system (e.g., DNA-binding domain or transcriptional activation domain) from the conditional feature of the split system.