### PR TITLE
Restore annotations for obsoleted terms.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -8713,6 +8713,10 @@ property_value: http://purl.org/dc/terms/date "2022-04-26T11:49:16Z" xsd:dateTim
 [Term]
 id: FBcv:0007053
 name: obsolete conditional split driver - transcription activation fragment
+def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:32:02Z" xsd:dateTime
 is_obsolete: true
 consider: FBcv:0005055
 consider: FBcv:0009028
@@ -8720,6 +8724,10 @@ consider: FBcv:0009028
 [Term]
 id: FBcv:0007054
 name: obsolete light-regulated split driver - transcription activation fragment
+def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:33:41Z" xsd:dateTime
 is_obsolete: true
 consider: FBcv:0005055
 consider: FBcv:0009029
@@ -8727,6 +8735,10 @@ consider: FBcv:0009029
 [Term]
 id: FBcv:0007055
 name: obsolete small molecule-regulated split driver - transcription activation fragment
+def: "Sequence encoding a transcription activation domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a DNA-binding domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:34:38Z" xsd:dateTime
 is_obsolete: true
 consider: FBcv:0005055
 consider: FBcv:0009030
@@ -8734,6 +8746,10 @@ consider: FBcv:0009030
 [Term]
 id: FBcv:0007056
 name: obsolete conditional split driver - DNA-binding fragment
+def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by a particular stimulus. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:35:30Z" xsd:dateTime
 is_obsolete: true
 consider: FBcv:0005054
 consider: FBcv:0009028
@@ -8741,6 +8757,10 @@ consider: FBcv:0009028
 [Term]
 id: FBcv:0007057
 name: obsolete light-regulated split driver - DNA-binding fragment
+def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by irradiation with a pulse of light. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate light stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:37:56Z" xsd:dateTime
 is_obsolete: true
 consider: FBcv:0005054
 consider: FBcv:0009029
@@ -8748,9 +8768,13 @@ consider: FBcv:0009029
 [Term]
 id: FBcv:0007058
 name: obsolete small molecule-regulated split driver - DNA-binding fragment
+def: "Sequence encoding a site-specific DNA-binding domain fused to a heterodimerization domain, where the process of heterodimerization mediated by this domain can be regulated by binding to a small molecule, such as an ion or ligand. A functional transcription driver can be reconstituted in vivo if this split system component is brought together with a split system component that encodes a transcription activation domain fused to the complementary heterodimerization domain and the appropriate small molecule stimulus is applied." [FBC:GM]
+comment: Obsoleted in favor of terms that do not conflate the type of the fragment with the type of conditional regulation.
+property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
+property_value: http://purl.org/dc/terms/date "2022-05-04T14:38:38Z" xsd:dateTime
 is_obsolete: true
+consider: FBcv:0005054
 consider: FBcv:0009030
-created_by: FBcv:0005054
 
 [Term]
 id: FBcv:0007059


### PR DESCRIPTION
This partially reverts commit 02787248e136cb6c8c0e4d5d79ead33f00cc4b31 by restoring the annotations on the terms obsoleted in that commit.