### PR TITLE
Add new split component terms.

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9191,6 +9191,24 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2023-07-31T17:18:43Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009031
+name: split protease
+namespace: experimental_tool_descriptor
+def: "Catalytically inactive fragment of a protease. A functional protease can be reconstituted when complementary split protease fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-03T13:12:34Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009032
+name: split bioluminescence reporter
+namespace: experimental_tool_descriptor
+def: "Catalytically inactive fragment of a bioluminescence reporter. A functional bioluminescence reporter can be reconstituted when complementary split bioluminescence reporter fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005053 ! split reporter enzyme
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-03T13:17:31Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.


### PR DESCRIPTION
This PR adds a couple of new split system components, `split protease` and `split bioluminescence reporter`.

closes #230
closes #229