### PR TITLE
Add new experimental tools

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9209,6 +9209,24 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-05-03T13:17:31Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009033
+name: conditional split protease
+namespace: experimental_tool_descriptor
+def: "Catalytically inactive fragment of a protease that can be used to reconstitute a functional protease when brought together in vivo with a complementary split protease fragment, where the process that brings the complementary fragments together can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0009031 ! split protease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-29T10:04:16Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009034
+name: light-regulated split protease
+namespace: experimental_tool_descriptor
+def: "Catalytically inactive fragment of a protease that can be used to reconstitute a functional protease when brought together in vivo with a complementary split protease fragment, where the process that brings the complementary fragments together can be regulated by irradiation with a pulse of light." [FBC:GM]
+is_a: FBcv:0009033 ! conditional split protease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-29T10:06:15Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9227,6 +9227,15 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-05-29T10:06:15Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009035
+name: split cell ablation tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a cell ablation tool. A functional cell ablation tool can be reconstituted when complementary split cell ablation tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-29T10:09:01Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9236,6 +9236,24 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-05-29T10:09:01Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009036
+name: conditional protease target site
+namespace: experimental_tool_descriptor
+def: "A peptide sequence that can act as a recognition site for a protease (an enzyme that catalyzes hydrolysis of a peptide bond), where this property can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0009024 ! protease target site
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-29T10:12:31Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009037
+name: light-regulated protease target site
+namespace: experimental_tool_descriptor
+def: "A peptide sequence that can act as a recognition site for a protease (an enzyme that catalyzes hydrolysis of a peptide bond), where this property can be regulated by irradiation with a pulse of light." [FBC:GM]
+is_a: FBcv:0009036 ! conditional protease target site
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-05-29T10:13:50Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.


### PR DESCRIPTION
This PR adds new terms for some experimental tools requested by @gm119 

* `conditional split protease` and `light-regulated split protease` (#232);
* `split cell ablation tool` (#233);
* `conditional protease target site` and `light-regulated protease target site` (#234).