### PR TITLE
New experimental tool descriptors

### DIFF
--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9254,6 +9254,24 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-05-29T10:13:50Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009038
+name: conditional RNA-guided nuclease
+namespace: experimental_tool_descriptor
+def: "An enzyme that catalyzes hydrolysis of DNA in a site-specific manner, where the specificity is determined by a guide RNA that contains sequence complementary to the DNA sequence of interest (rather than being an inherent property of the nuclease itself) and where the nuclease activity can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0005078 ! RNA-guided nuclease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T10:42:33Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009039
+name: small molecule-regulated RNA-guided nuclease
+namespace: experimental_tool_descriptor
+def: "An enzyme that catalyzes hydrolysis of DNA in a site-specific manner, where the specificity is determined by a guide RNA that contains sequence complementary to the DNA sequence of interest (rather than being an inherent property of the nuclease itself) and where the nuclease activity can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
+is_a: FBcv:0009038 ! conditional RNA-guided nuclease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T10:44:12Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -7919,7 +7919,7 @@ property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTim
 id: FBcv:0005051
 name: split system component
 namespace: experimental_tool_descriptor
-def: "Component that forms part of a 'split system'. A split system component corresponds to a non-functional fragment of a functional experimental tool that would normally be encoded by a single gene product. When combined with another appropriate split system component in vivo, a functional experimental tool is produced. The fragments of a split system can be brought together in vivo in a number of different ways; for example, by fusing fragments to peptides that physically interact in vivo." [FBC:GM]
+def: "Component that forms part of a 'split system'. A split system component corresponds to a non-functional fragment of a functional experimental tool. When combined with another appropriate split system component in vivo, a functional experimental tool is produced. The fragments of a split system can be brought together in vivo in a number of different ways; for example, by fusing fragments to peptides that physically interact in vivo." [FBC:GM]
 is_a: FBcv:0005001 ! experimental tool descriptor
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
@@ -9396,6 +9396,15 @@ def: "Non-functional fragment of an RNA-guided nuclease that can be used to reco
 is_a: FBcv:0009052 ! conditional split RNA-guided nuclease
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
 property_value: http://purl.org/dc/terms/date "2024-06-24T11:35:10Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009054
+name: split protein splicing tag
+namespace: experimental_tool_descriptor
+def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and that can catalyze protein splicing when brought together with a complementary split protein splicing tag in vivo. Typically used to join two separate protein sequences by trans-splicing; in this case the two separate protein sequences are each initially tagged with one half of a pair of complementary split protein splicing tags. Alternatively, if both halves of a pair of complementary split protein splicing tags are used to tag each end of a single protein sequence, they can be used to generate a cyclized protein molecule." [FBC:GM]
+is_a: FBcv:0009046 ! split gene product engineering tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:44:00Z" xsd:dateTime
 
 [Term]
 id: FBcv:0010000

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -7929,7 +7929,7 @@ id: FBcv:0005052
 name: split fluorescent protein
 namespace: experimental_tool_descriptor
 def: "Non-fluorescent fragment of a fluorescent protein. A functional fluorophore can be reconstituted if a split fluorescent protein fragment is expressed with a complementary split fluorescent protein fragment and the fragments are brought together in vivo, permitting the study of biological interactions. Protein-protein interactions can be studied using the bimolecular fluorescence complementation (BiFC) technique, where a fluorescent protein is reconstituted if the two complementary split fluorescent protein fragments are fused to interacting proteins or protein domains that bring the split halves together into the same macromolecular complex. Associations between closely apposed cells can be studied if the two complementary split fluorescent protein fragments are tethered to the surface of these cells, for example to study connectivity in the nervous system using the GFP Reconstitution Across Synaptic Partners (GRASP) technique." [FBC:GM, PMID:11983170, PMID:18255029]
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009048 ! split protein detection tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
 
@@ -7938,7 +7938,7 @@ id: FBcv:0005053
 name: split reporter enzyme
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the protein product encoded by a transgenic locus or modified endogenous locus and that encodes a catalytically inactive fragment of an enzyme whose activity can be used to detect the presence of that protein product when complementary split reporter enzyme fragments are brought together in vivo. Fragments may be brought together when fused to peptides that physically interact, permitting the study of protein-protein interactions." [FBC:GM, http://orcid.org/0000-0002-1373-1705, PMID:9237989]
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009048 ! split protein detection tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-0027-0858
 property_value: http://purl.org/dc/terms/date "2017-06-28T11:41:27Z" xsd:dateTime
 
@@ -8501,7 +8501,7 @@ id: FBcv:0007028
 name: split recombinase
 namespace: experimental_tool_descriptor
 def: "Catalytically inactive fragment of a recombinase. A functional recombinase can be reconstituted when complementary split recombinase fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009045 ! split genome engineering tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
 property_value: http://purl.org/dc/terms/date "2019-06-26T07:55:34Z" xsd:dateTime
 
@@ -9195,7 +9195,7 @@ id: FBcv:0009031
 name: split protease
 namespace: experimental_tool_descriptor
 def: "Catalytically inactive fragment of a protease. A functional protease can be reconstituted when complementary split protease fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009046 ! split gene product engineering tool
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
 property_value: http://purl.org/dc/terms/date "2024-05-03T13:12:34Z" xsd:dateTime
 
@@ -9231,7 +9231,7 @@ id: FBcv:0009035
 name: split cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Non-functional fragment of a cell ablation tool. A functional cell ablation tool can be reconstituted when complementary split cell ablation tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
-is_a: FBcv:0005051 ! split system component
+is_a: FBcv:0009049 ! split cell viability regulation tool
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
 property_value: http://purl.org/dc/terms/date "2024-05-29T10:09:01Z" xsd:dateTime
 

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9272,6 +9272,33 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-06-24T10:44:12Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009040
+name: protein splicing tag
+namespace: experimental_tool_descriptor
+def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product undergoing protein splicing." [FBC:GM]
+is_a: FBcv:0009022 ! gene product engineering tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T10:47:32Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009041
+name: conditional protein splicing tag
+namespace: experimental_tool_descriptor
+def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product undergoing protein splicing, where this process can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0009040 ! protein splicing tag
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T10:48:27Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009042
+name: small molecule-regulated protein splicing tag
+namespace: experimental_tool_descriptor
+def: "Sequence that forms part of the protein product encoded by a transgenic locus or modified endogenous locus and which results in the tagged gene product undergoing protein splicing, where this process can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
+is_a: FBcv:0009041 ! conditional protein splicing tag
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T10:49:38Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -8362,7 +8362,7 @@ name: cell ablation tool
 namespace: experimental_tool_descriptor
 def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to ablate a specific cell or anatomical structure." [FBC:GM]
 subset: common_tool_use
-is_a: FBcv:0005001 ! experimental tool descriptor
+is_a: FBcv:0009043 ! cell viability regulation tool
 property_value: http://purl.org/dc/terms/contributor http://orcid.org/0000-0002-1373-1705
 property_value: http://purl.org/dc/terms/date "2019-06-25T10:53:21Z" xsd:dateTime
 
@@ -9297,6 +9297,24 @@ def: "Sequence that forms part of the protein product encoded by a transgenic lo
 is_a: FBcv:0009041 ! conditional protein splicing tag
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
 property_value: http://purl.org/dc/terms/date "2024-06-24T10:49:38Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009043
+name: cell viability regulation tool
+namespace: experimental_tool_descriptor
+def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to regulate the viability of a specific cell or anatomical structure." [FBC:GM]
+is_a: FBcv:0005001 ! experimental tool descriptor
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:04:56Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009044
+name: cell death inhibition tool
+namespace: experimental_tool_descriptor
+def: "Sequence that forms all or part of the gene product encoded by a transgenic locus or modified endogenous locus and that confers a specific property used to inhibit cell death in a specific cell or anatomical structure." [FBC:GM]
+is_a: FBcv:0009043 ! cell viability regulation tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:06:20Z" xsd:dateTime
 
 [Term]
 id: FBcv:0010000

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9362,6 +9362,42 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-06-24T11:16:29Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009050
+name: split nuclease
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a nuclease. A functional nuclease can be reconstituted when complementary split nuclease fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0009045 ! split genome engineering tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:30:43Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009051
+name: split RNA-guided nuclease
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of an RNA-guided nuclease. A functional RNA-guided nuclease can be reconstituted when complementary split RNA-guided nuclease fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0009050 ! split nuclease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:31:36Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009052
+name: conditional split RNA-guided nuclease
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of an RNA-guided nuclease that can be used to reconstitute a functional RNA-guided nuclease when brought together in vivo with a complementary split RNA-guided nuclease fragment, where the process that brings the complementary fragments together can be regulated in response to a particular stimulus." [FBC:GM]
+is_a: FBcv:0009051 ! split RNA-guided nuclease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:33:51Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009053
+name: small molecule-regulated split RNA-guided nuclease
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of an RNA-guided nuclease that can be used to reconstitute a functional RNA-guided nuclease when brought together in vivo with a complementary split RNA-guided nuclease fragment, where the process that brings the complementary fragments together can be regulated by binding to a small molecule, such as an ion or ligand." [FBC:GM]
+is_a: FBcv:0009052 ! conditional split RNA-guided nuclease
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:35:10Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.

--- a/src/ontology/fbcv-edit.obo
+++ b/src/ontology/fbcv-edit.obo
@@ -9317,6 +9317,51 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002
 property_value: http://purl.org/dc/terms/date "2024-06-24T11:06:20Z" xsd:dateTime
 
 [Term]
+id: FBcv:0009045
+name: split genome engineering tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a genome engineering tool. A functional genome engineering tool can be reconstituted when complementary split genome engineering tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:11:57Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009046
+name: split gene product engineering tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a gene product engineering tool. A functional gene product engineering tool can be reconstituted when complementary split gene product engineering tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:13:39Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009047
+name: split gene product detection tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a gene product detection tool. A functional gene product detection tool can be reconstituted when complementary split gene product detection tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:14:32Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009048
+name: split protein detection tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a protein detection tool. A functional protein detection tool can be reconstituted when complementary split protein detection tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0009047 ! split gene product detection tool
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:15:29Z" xsd:dateTime
+
+[Term]
+id: FBcv:0009049
+name: split cell viability regulation tool
+namespace: experimental_tool_descriptor
+def: "Non-functional fragment of a cell viability regulation tool. A functional cell viability regulation tool can be reconstituted when complementary split cell viability regulation tool fragments are brought together in vivo, for example by fusing the fragments to peptides that physically interact." [FBC:GM]
+is_a: FBcv:0005051 ! split system component
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-06-24T11:16:29Z" xsd:dateTime
+
+[Term]
 id: FBcv:0010000
 name: obsolete living stock
 comment: Consider - FBsv:0000002.


### PR DESCRIPTION
This PR adds a handful of experimental tool descriptors as requested by @gm119 , namely

* `small molecule-regulated RNA-guided nuclease` (and its parent `conditional RNA-guided nuclease`) (#237);
* `small molecule-regulated protein splicing tag` (and parents) (#238);
* `cell death inhibition tool` (and its parent `cell viability regulation tool`, under which the existing `cell ablation tool` is also re-classified) (#239);
* `small molecule-regulated split RNA-guided nuclease` (and parents) (#242);
* `split protein splicing tag` (#241);

To accommodate the last two, new grouping terms are also introduced under `split system components` (#240, #243).