### PR TITLE
Derive fbcv.obo from the -simple artefact.

### DIFF
--- a/src/ontology/fbcv.Makefile
+++ b/src/ontology/fbcv.Makefile
@@ -81,7 +81,7 @@ $(ONT)-simple.obo: $(ONT)-simple.owl
 	rm -f $@.tmp.obo $@.tmp
 
 # We want the OBO release to be based on the simple release. It needs to be annotated however in the way map releases (fbbt.owl) are annotated.
-$(ONT).obo: $(ONT).owl
+$(ONT).obo: $(ONT)-simple.owl
 	$(ROBOT)  annotate --input $< --ontology-iri $(URIBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY) \
 	convert --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo &&\
 	cat $@.tmp.obo | grep -v ^owl-axioms > $@.tmp &&\


### PR DESCRIPTION
A comment in the custom Makefile says that we want fbcv.obo to be derived from fbcv-simple, but the actual rule immediately below that comment proceeds to derive fbcv.obo from fbcv.owl (which, as per the ODK rules, is the same thing as fbcv-full.owl).

In all other FlyBase ontologies (FBdv, FBbt, and DPO), the main obo file X.obo is derived from X-simple.owl, so there should be no reason for FBcv to do otherwise, especially since the comment explicitly states that this was the original intention.